### PR TITLE
fix(db): remove velo provider naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,5 +55,5 @@ CLAUDE.local.md
 
 # local mcp config
 .mcp.json
-/velo-source/
+/postgres-source/
 /neon-source/

--- a/apps/app/schema/011-database-v-next.sql
+++ b/apps/app/schema/011-database-v-next.sql
@@ -3,7 +3,7 @@ CREATE TABLE databases (
   project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
   name TEXT NOT NULL,
   engine TEXT NOT NULL CHECK (engine IN ('postgres', 'mysql')),
-  provider TEXT NOT NULL CHECK (provider IN ('velo', 'mysql-docker')),
+  provider TEXT NOT NULL CHECK (provider IN ('postgres-docker', 'mysql-docker')),
   created_at INTEGER NOT NULL,
   UNIQUE(project_id, name)
 );

--- a/apps/app/schema/015-database-provider-rename.sql
+++ b/apps/app/schema/015-database-provider-rename.sql
@@ -1,0 +1,43 @@
+PRAGMA foreign_keys = OFF;
+
+BEGIN EXCLUSIVE;
+
+CREATE TABLE databases_new (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  name TEXT NOT NULL,
+  engine TEXT NOT NULL CHECK (engine IN ('postgres', 'mysql')),
+  provider TEXT NOT NULL CHECK (provider IN ('postgres-docker', 'mysql-docker')),
+  created_at INTEGER NOT NULL,
+  UNIQUE(project_id, name)
+);
+
+INSERT INTO databases_new (
+  id,
+  project_id,
+  name,
+  engine,
+  provider,
+  created_at
+)
+SELECT
+  id,
+  project_id,
+  name,
+  engine,
+  CASE
+    WHEN provider = 'mysql-docker' THEN 'mysql-docker'
+    ELSE 'postgres-docker'
+  END AS provider,
+  created_at
+FROM databases;
+
+DROP TABLE databases;
+
+ALTER TABLE databases_new RENAME TO databases;
+
+CREATE INDEX idx_databases_project_id ON databases(project_id);
+
+COMMIT;
+
+PRAGMA foreign_keys = ON;

--- a/apps/app/src/app/projects/[id]/_components/database-content.tsx
+++ b/apps/app/src/app/projects/[id]/_components/database-content.tsx
@@ -13,7 +13,7 @@ export interface CanvasDatabase {
   id: string;
   name: string;
   engine: "postgres" | "mysql";
-  provider: "velo" | "mysql-docker";
+  provider: "postgres-docker" | "mysql-docker";
 }
 
 export interface CanvasDatabaseAttachment {

--- a/apps/app/src/app/projects/[id]/_components/database-sidebar.tsx
+++ b/apps/app/src/app/projects/[id]/_components/database-sidebar.tsx
@@ -55,6 +55,7 @@ import {
   getDatabaseLogoAlt,
   getDatabaseLogoUrl,
 } from "@/lib/database-logo";
+import { normalizeDatabaseProvider } from "@/lib/database-provider";
 import { orpc } from "@/lib/orpc-client";
 import { getTimeAgo } from "@/lib/time";
 import {
@@ -248,7 +249,7 @@ function PostgresSettingsPanel({
             <div className="space-y-2 text-sm text-neutral-300">
               <div>Name: {databaseName}</div>
               <div>Engine: {databaseEngine}</div>
-              <div>Provider: {databaseProvider}</div>
+              <div>Provider: {normalizeDatabaseProvider(databaseProvider)}</div>
               <div>Default branch: {defaultBranchName ?? "main"}</div>
             </div>
           </SettingCard>
@@ -859,7 +860,7 @@ export function DatabaseSidebar({
                     {database.engine}
                   </span>
                   <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-700 px-2.5 py-1 text-xs text-neutral-400">
-                    {database.provider}
+                    {normalizeDatabaseProvider(database.provider)}
                   </span>
                   {envAttachment && (
                     <span className="inline-flex items-center gap-1.5 rounded-full bg-neutral-700 px-2.5 py-1 text-xs text-neutral-400">
@@ -1035,7 +1036,9 @@ export function DatabaseSidebar({
               <div className="space-y-2 text-sm text-neutral-300">
                 <div>Name: {database.name}</div>
                 <div>Engine: {database.engine}</div>
-                <div>Provider: {database.provider}</div>
+                <div>
+                  Provider: {normalizeDatabaseProvider(database.provider)}
+                </div>
                 <div>
                   Current instance:{" "}
                   {envAttachment?.targetName ?? "not attached"}

--- a/apps/app/src/app/projects/[id]/databases/[databaseId]/page.tsx
+++ b/apps/app/src/app/projects/[id]/databases/[databaseId]/page.tsx
@@ -9,6 +9,7 @@ import {
   useDatabaseAttachments,
   useDatabaseTargets,
 } from "@/hooks/use-databases";
+import { normalizeDatabaseProvider } from "@/lib/database-provider";
 
 export default function DatabaseOverviewPage() {
   const params = useParams();
@@ -46,7 +47,7 @@ export default function DatabaseOverviewPage() {
                 variant="outline"
                 className="border-neutral-700 text-neutral-300"
               >
-                {database.provider}
+                {normalizeDatabaseProvider(database.provider)}
               </Badge>
             </div>
           </CardTitle>

--- a/apps/app/src/app/projects/[id]/databases/[databaseId]/settings/page.tsx
+++ b/apps/app/src/app/projects/[id]/databases/[databaseId]/settings/page.tsx
@@ -8,6 +8,7 @@ import { SettingCard } from "@/components/setting-card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { useDatabase, useDeleteDatabase } from "@/hooks/use-databases";
+import { normalizeDatabaseProvider } from "@/lib/database-provider";
 
 export default function DatabaseSettingsPage() {
   const params = useParams();
@@ -56,7 +57,7 @@ export default function DatabaseSettingsPage() {
             variant="outline"
             className="border-neutral-700 text-neutral-300"
           >
-            {database.provider}
+            {normalizeDatabaseProvider(database.provider)}
           </Badge>
         </div>
       </SettingCard>

--- a/apps/app/src/app/projects/[id]/databases/page.tsx
+++ b/apps/app/src/app/projects/[id]/databases/page.tsx
@@ -10,6 +10,7 @@ import {
   useDatabases,
   useEnvironmentDatabaseAttachments,
 } from "@/hooks/use-databases";
+import { normalizeDatabaseProvider } from "@/lib/database-provider";
 import { orpc } from "@/lib/orpc-client";
 
 export default function ProjectDatabasesPage() {
@@ -77,7 +78,7 @@ export default function ProjectDatabasesPage() {
                         variant="outline"
                         className="border-neutral-700 text-neutral-300"
                       >
-                        {database.provider}
+                        {normalizeDatabaseProvider(database.provider)}
                       </Badge>
                     </div>
 

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -2,7 +2,7 @@ import { oc } from "@orpc/contract";
 import { z } from "zod";
 
 const databaseEngineSchema = z.enum(["postgres", "mysql"]);
-const databaseProviderSchema = z.enum(["velo", "mysql-docker"]);
+const databaseProviderSchema = z.enum(["postgres-docker", "mysql-docker"]);
 const databaseTargetKindSchema = z.enum(["branch", "instance"]);
 const databaseTargetLifecycleSchema = z.enum(["active", "stopped", "expired"]);
 const attachmentModeSchema = z.enum(["managed", "manual"]);

--- a/apps/app/src/lib/database-provider.ts
+++ b/apps/app/src/lib/database-provider.ts
@@ -1,0 +1,8 @@
+export type DatabaseProvider = "postgres-docker" | "mysql-docker";
+
+export function normalizeDatabaseProvider(value: string): DatabaseProvider {
+  if (value === "mysql-docker") {
+    return "mysql-docker";
+  }
+  return "postgres-docker";
+}

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -4,6 +4,10 @@ import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { nanoid } from "nanoid";
 import { getDatabaseBranchAlias } from "./database-hostname";
+import {
+  type DatabaseProvider,
+  normalizeDatabaseProvider,
+} from "./database-provider";
 import { db } from "./db";
 import type {
   Databases,
@@ -41,7 +45,6 @@ import { slugify } from "./slugify";
 const execAsync = promisify(exec);
 
 export type DatabaseEngine = "postgres" | "mysql";
-export type DatabaseProvider = "velo" | "mysql-docker";
 export type DatabaseTargetKind = "branch" | "instance";
 export type DatabaseTargetLifecycle = "active" | "stopped" | "expired";
 export type AttachmentMode = "managed" | "manual";
@@ -162,7 +165,7 @@ function assertMemoryLimit(value: string): void {
 }
 
 function getProvider(engine: DatabaseEngine): DatabaseProvider {
-  return engine === "postgres" ? "velo" : "mysql-docker";
+  return engine === "postgres" ? "postgres-docker" : "mysql-docker";
 }
 
 function getTargetKind(engine: DatabaseEngine): DatabaseTargetKind {
@@ -186,14 +189,23 @@ function getDatabaseNameSlug(name: string): string {
   return base.slice(0, 48);
 }
 
-async function assertVeloHostReady(): Promise<void> {
+async function assertPostgresHostReady(): Promise<void> {
   try {
     await execAsync("docker info --format '{{.ServerVersion}}'");
   } catch {
     throw new Error(
-      "Postgres requires a Velo-ready Docker host. Docker is not available.",
+      "Postgres requires a Docker host. Docker is not available.",
     );
   }
+}
+
+function normalizeDatabase(
+  database: Selectable<Databases>,
+): Selectable<Databases> {
+  return {
+    ...database,
+    provider: normalizeDatabaseProvider(database.provider),
+  };
 }
 
 function parseProviderRef(json: string): ProviderRef {
@@ -601,7 +613,7 @@ async function getDatabaseById(
     throw new Error("Database not found");
   }
 
-  return database;
+  return normalizeDatabase(database);
 }
 
 async function getTargetById(
@@ -766,7 +778,7 @@ export async function createDatabase(input: {
   assertDatabaseName(input.name);
 
   if (input.engine === "postgres") {
-    await assertVeloHostReady();
+    await assertPostgresHostReady();
     await assertPostgresBranchingReady();
   }
 
@@ -2176,12 +2188,14 @@ export async function ensureEnvironmentPostgresDefaults(
 }
 
 export async function listDatabasesByProject(projectId: string) {
-  return db
+  const databases = await db
     .selectFrom("databases")
     .selectAll()
     .where("projectId", "=", projectId)
     .orderBy("createdAt", "asc")
     .execute();
+
+  return databases.map(normalizeDatabase);
 }
 
 export async function listDatabaseTargets(databaseId: string) {

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -566,7 +566,7 @@ export const databasesSchema = z.object({
   projectId: z.string(),
   name: z.string(),
   engine: z.enum(["postgres", "mysql"]),
-  provider: z.enum(["velo", "mysql-docker"]),
+  provider: z.enum(["postgres-docker", "mysql-docker"]),
   createdAt: z.number(),
 });
 
@@ -575,7 +575,7 @@ export const newDatabasesSchema = z.object({
   projectId: z.string(),
   name: z.string(),
   engine: z.enum(["postgres", "mysql"]),
-  provider: z.enum(["velo", "mysql-docker"]),
+  provider: z.enum(["postgres-docker", "mysql-docker"]),
   createdAt: z.number(),
 });
 
@@ -584,7 +584,7 @@ export const databasesUpdateSchema = z.object({
   projectId: z.string().optional(),
   name: z.string().optional(),
   engine: z.enum(["postgres", "mysql"]).optional(),
-  provider: z.enum(["velo", "mysql-docker"]).optional(),
+  provider: z.enum(["postgres-docker", "mysql-docker"]).optional(),
   createdAt: z.number().optional(),
 });
 

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -63,7 +63,7 @@ export interface Databases {
   projectId: string;
   name: string;
   engine: 'postgres' | 'mysql';
-  provider: 'velo' | 'mysql-docker';
+  provider: 'postgres-docker' | 'mysql-docker';
   createdAt: number;
 }
 

--- a/apps/app/src/lib/migrate.ts
+++ b/apps/app/src/lib/migrate.ts
@@ -105,6 +105,27 @@ function runMigrationsWithDb(
 
     const filePath = join(schemaDir, file);
     const sql = readFileSync(filePath, "utf-8");
+    const needsForeignKeysOff = sql.includes("PRAGMA foreign_keys = OFF");
+
+    if (needsForeignKeysOff) {
+      try {
+        sqlite.exec(sql);
+        sqlite
+          .prepare("INSERT INTO _migrations (name, applied_at) VALUES (?, ?)")
+          .run(file, Date.now());
+        console.log(`[migrate] Applied: ${file}`);
+        appliedCount++;
+      } catch (err) {
+        try {
+          sqlite.exec("ROLLBACK");
+        } catch (rollbackError) {
+          console.error("[migrate] Rollback failed:", rollbackError);
+        }
+        console.error(`[migrate] Failed to apply ${file}:`, err);
+        throw err;
+      }
+      continue;
+    }
 
     sqlite.exec("BEGIN EXCLUSIVE");
     try {

--- a/biome.json
+++ b/biome.json
@@ -24,7 +24,7 @@
       "!**/node_modules",
       "!**/data",
       "!**/repos",
-      "!**/velo-source",
+      "!**/postgres-source",
       "!**/neon-source",
       "!**/*.css",
       "!**/db-types.ts",


### PR DESCRIPTION
## Summary
- remove `velo` naming from database provider types, schema checks, runtime mapping, and UI display
- add provider normalization so old `velo` values still map to `postgres-docker`
- add migration `015-database-provider-rename.sql` to convert existing rows to new provider value
- update migration runner to handle migrations that manage foreign key toggling

## Validation
- bun run typecheck
- bun run lint
