### PR TITLE
fix(projects): polish left menu picker and resource list

### DIFF
--- a/apps/app/src/app/(workspace)/layout.tsx
+++ b/apps/app/src/app/(workspace)/layout.tsx
@@ -188,7 +188,7 @@ export default function WorkspaceLayout({
           <WorkspaceLeftMenu />
         )}
 
-        <div className="min-h-0 flex-1 bg-neutral-950/20">
+        <div className="flex min-h-0 flex-1 flex-col bg-neutral-950/20">
           {showMainContentHeader && (
             <MainContentHeader title={mainHeaderTitle} />
           )}

--- a/apps/app/src/app/(workspace)/layout.tsx
+++ b/apps/app/src/app/(workspace)/layout.tsx
@@ -41,7 +41,12 @@ export default function WorkspaceLayout({
     /^\/projects\/[^/]+\/environments\/[^/]+\/(services|databases)\//.test(
       pathname,
     );
-  const showMainContentHeader = true;
+  const isSettingsPage =
+    pathname === "/settings" ||
+    pathname.startsWith("/settings/") ||
+    /^\/projects\/[^/]+\/settings(\/|$)/.test(pathname);
+  const shouldCenterContent = isSettingsPage && !isResourceDetailPage;
+  const showMainContentHeader = !isResourceDetailPage;
 
   const [createServiceModalOpen, setCreateServiceModalOpen] = useState(false);
   const [createEnvDialogOpen, setCreateEnvDialogOpen] = useState(false);
@@ -190,6 +195,8 @@ export default function WorkspaceLayout({
           <div className={bodyClassName}>
             {isProjectPage && isEnvironmentsLoading ? (
               <Skeleton className="h-32 w-full" />
+            ) : shouldCenterContent ? (
+              <div className="mx-auto w-full max-w-[1200px]">{children}</div>
             ) : (
               children
             )}

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
@@ -1,24 +1,27 @@
 "use client";
 
 import { useQuery } from "@tanstack/react-query";
-import { Plus } from "lucide-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useMemo } from "react";
+import { type SyntheticEvent, useMemo } from "react";
 import { BrandLockup } from "@/components/brand-lockup";
 import { EnvironmentPicker } from "@/components/environment-picker";
 import { LeftMenuFooter } from "@/components/left-menu-footer";
 import { ProjectPicker } from "@/components/project-picker";
 import { ShellTopRow } from "@/components/shell-top-row";
 import { StatusDot } from "@/components/status-dot";
-import { Button } from "@/components/ui/button";
 import {
   useDatabases,
   useEnvironmentDatabaseAttachments,
 } from "@/hooks/use-databases";
 import { useProject, useProjects } from "@/hooks/use-projects";
 import { api } from "@/lib/api";
+import {
+  DATABASE_LOGO_FALLBACK,
+  getDatabaseLogoUrl,
+} from "@/lib/database-logo";
 import { orpc } from "@/lib/orpc-client";
+import { FALLBACK_ICON, getServiceIcon } from "@/lib/service-logo";
 import { getPreferredDomain } from "@/lib/service-url";
 
 interface ProjectLeftMenuProps {
@@ -35,6 +38,59 @@ function getResourceItemClass(isActive: boolean): string {
     return "block w-full rounded-lg border border-neutral-500 bg-neutral-800/70 px-3 py-2 text-left";
   }
   return "block w-full rounded-lg border border-transparent px-3 py-2 text-left transition-colors hover:border-neutral-700 hover:bg-neutral-900";
+}
+
+function handleImageFallback(
+  event: SyntheticEvent<HTMLImageElement>,
+  fallbackSrc: string,
+) {
+  const image = event.currentTarget;
+  if (image.src === fallbackSrc) {
+    return;
+  }
+  image.src = fallbackSrc;
+}
+
+interface ResourceListItemProps {
+  href: string;
+  isActive: boolean;
+  iconSrc: string;
+  iconFallback: string;
+  name: string;
+  subtitle: string;
+  status: string;
+}
+
+function ResourceListItem({
+  href,
+  isActive,
+  iconSrc,
+  iconFallback,
+  name,
+  subtitle,
+  status,
+}: ResourceListItemProps) {
+  return (
+    <Link href={href} className={getResourceItemClass(isActive)}>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <span className="flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-neutral-800 text-neutral-400">
+            <img
+              src={iconSrc}
+              alt=""
+              className="h-4 w-4 object-contain"
+              onError={function onIconError(event) {
+                handleImageFallback(event, iconFallback);
+              }}
+            />
+          </span>
+          <span className="truncate text-sm text-neutral-100">{name}</span>
+        </div>
+        <StatusDot status={status} className="shrink-0" />
+      </div>
+      <p className="mt-1 truncate text-xs text-neutral-500">{subtitle}</p>
+    </Link>
+  );
 }
 
 export function ProjectLeftMenu({
@@ -154,7 +210,7 @@ export function ProjectLeftMenu({
           </p>
           <Link
             href={`/projects/${projectId}/settings`}
-            className="text-xs text-neutral-400 transition-colors hover:text-neutral-100"
+            className="cursor-pointer text-xs text-neutral-400 transition-colors hover:text-neutral-100"
           >
             Settings
           </Link>
@@ -199,36 +255,26 @@ export function ProjectLeftMenu({
       </div>
 
       <div className="flex min-h-0 flex-1 flex-col">
-        <div className="border-b border-neutral-800 px-4 py-3">
-          <div className="flex items-center justify-between gap-2">
-            <div>
-              <p className="text-xs font-medium uppercase tracking-wide text-neutral-500">
-                Resources
-              </p>
-              <p className="mt-1 text-xs text-neutral-500">
-                {services.length} services · {databases.length} databases
-              </p>
-            </div>
-            <Button
-              size="sm"
-              variant="outline"
+        <div className="flex-1 space-y-4 overflow-auto px-3 py-3">
+          <div className="flex items-center justify-between px-1">
+            <p className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              Resources
+            </p>
+            <button
+              type="button"
               onClick={onOpenCreateService}
               disabled={!currentEnvId}
+              className="cursor-pointer text-xs text-neutral-400 transition-colors hover:text-neutral-100 disabled:cursor-not-allowed disabled:text-neutral-700"
             >
-              <Plus className="mr-1 h-3.5 w-3.5" />
               Add
-            </Button>
+            </button>
           </div>
-        </div>
 
-        <div className="flex-1 space-y-4 overflow-auto px-3 py-3">
-          {hasResources && services.length > 0 && (
-            <section className="space-y-1">
-              <p className="px-1 text-xs font-medium uppercase tracking-wide text-neutral-500">
-                Services
-              </p>
+          {hasResources && (
+            <div className="space-y-1">
               {services.map(function renderService(service) {
                 const deployment = service.latestDeployment;
+                const serviceIcon = getServiceIcon(service) ?? FALLBACK_ICON;
                 const url =
                   domains[service.id] ||
                   (serverIp && deployment?.hostPort
@@ -238,36 +284,19 @@ export function ProjectLeftMenu({
                   ? `/projects/${projectId}/environments/${currentEnvId}/services/${service.id}`
                   : `/projects/${projectId}`;
                 return (
-                  <Link
+                  <ResourceListItem
                     key={service.id}
                     href={href}
-                    className={getResourceItemClass(
-                      selectedServiceId === service.id,
-                    )}
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="truncate text-sm text-neutral-100">
-                        {service.name}
-                      </span>
-                      <StatusDot
-                        status={deployment?.status ?? "pending"}
-                        className="shrink-0"
-                      />
-                    </div>
-                    <p className="mt-1 truncate text-xs text-neutral-500">
-                      {url ?? "no public url"}
-                    </p>
-                  </Link>
+                    isActive={selectedServiceId === service.id}
+                    iconSrc={serviceIcon}
+                    iconFallback={FALLBACK_ICON}
+                    name={service.name}
+                    subtitle={url ?? "no public url"}
+                    status={deployment?.status ?? "pending"}
+                  />
                 );
               })}
-            </section>
-          )}
 
-          {hasResources && databases.length > 0 && (
-            <section className="space-y-1">
-              <p className="px-1 text-xs font-medium uppercase tracking-wide text-neutral-500">
-                Databases
-              </p>
               {databases.map(function renderDatabase(database) {
                 const attachment =
                   databaseAttachmentById.get(database.id) ?? null;
@@ -280,29 +309,19 @@ export function ProjectLeftMenu({
                   ? `/projects/${projectId}/environments/${currentEnvId}/databases/${database.id}`
                   : `/projects/${projectId}`;
                 return (
-                  <Link
+                  <ResourceListItem
                     key={database.id}
                     href={href}
-                    className={getResourceItemClass(
-                      selectedDatabaseId === database.id,
-                    )}
-                  >
-                    <div className="flex items-center justify-between gap-2">
-                      <span className="truncate text-sm text-neutral-100">
-                        {database.name}
-                      </span>
-                      <StatusDot
-                        status={attachment?.targetLifecycleStatus ?? "stopped"}
-                        className="shrink-0"
-                      />
-                    </div>
-                    <p className="mt-1 truncate text-xs text-neutral-500">
-                      {database.engine} · {branchLabel}
-                    </p>
-                  </Link>
+                    isActive={selectedDatabaseId === database.id}
+                    iconSrc={getDatabaseLogoUrl(database.engine)}
+                    iconFallback={DATABASE_LOGO_FALLBACK}
+                    name={database.name}
+                    subtitle={`${database.engine} · ${branchLabel}`}
+                    status={attachment?.targetLifecycleStatus ?? "stopped"}
+                  />
                 );
               })}
-            </section>
+            </div>
           )}
 
           {!hasResources && (

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/resource-sidebar-core.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/resource-sidebar-core.tsx
@@ -2,7 +2,7 @@
 
 import type React from "react";
 import { useEffect, useMemo, useState } from "react";
-import { ResourceSidebar } from "./resource-sidebar";
+import { type ResourceContentMode, ResourceSidebar } from "./resource-sidebar";
 
 export type CoreSidebarTab = "overview" | "deployments" | "logs" | "settings";
 
@@ -30,6 +30,7 @@ interface ResourceSidebarCoreProps<T extends string = never> {
   tabOrder?: Array<CoreSidebarTab | T>;
   initialTab?: CoreSidebarTab | T;
   onActiveTabChange?: (tab: CoreSidebarTab | T) => void;
+  getContentMode?: (tab: CoreSidebarTab | T) => ResourceContentMode;
 }
 
 const CORE_TABS: { id: CoreSidebarTab; label: string }[] = [
@@ -59,6 +60,7 @@ export function ResourceSidebarCore<T extends string = never>({
   tabOrder,
   initialTab,
   onActiveTabChange,
+  getContentMode,
 }: ResourceSidebarCoreProps<T>) {
   const [activeTab, setActiveTab] = useState<CoreSidebarTab | T>("overview");
 
@@ -157,6 +159,7 @@ export function ResourceSidebarCore<T extends string = never>({
       tabs={tabs}
       activeTab={activeTab}
       onTabChange={setActiveTab}
+      contentMode={getContentMode?.(activeTab) ?? "full"}
     >
       {content}
     </ResourceSidebar>

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/resource-sidebar.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/resource-sidebar.tsx
@@ -10,6 +10,8 @@ export interface ResourceSidebarTab<T extends string> {
   label: string;
 }
 
+export type ResourceContentMode = "full" | "center";
+
 interface ResourceSidebarProps<T extends string> {
   isOpen: boolean;
   onClose: () => void;
@@ -18,6 +20,7 @@ interface ResourceSidebarProps<T extends string> {
   tabs: ResourceSidebarTab<T>[];
   activeTab: T;
   onTabChange: (tab: T) => void;
+  contentMode?: ResourceContentMode;
   children: React.ReactNode;
 }
 
@@ -29,15 +32,16 @@ export function ResourceSidebar<T extends string>({
   tabs,
   activeTab,
   onTabChange,
+  contentMode = "full",
   children,
 }: ResourceSidebarProps<T>) {
   if (!isOpen) {
     return null;
   }
 
-  const content = (
+  return (
     <div className="flex h-full min-h-0 flex-col">
-      <div className="flex flex-row items-center justify-between border-b border-neutral-800 px-4 py-3">
+      <div className="flex h-14 flex-row items-center justify-between border-b border-neutral-800 px-4">
         <div className="flex items-center gap-3">
           <div className="flex h-8 w-8 items-center justify-center rounded-lg bg-neutral-800 text-neutral-400">
             {icon}
@@ -62,11 +66,13 @@ export function ResourceSidebar<T extends string>({
           layoutId="sidebar-tabs"
         />
         <div className="flex min-h-0 flex-1 flex-col overflow-auto p-4">
-          {children}
+          {contentMode === "center" ? (
+            <div className="mx-auto w-full max-w-[1200px]">{children}</div>
+          ) : (
+            children
+          )}
         </div>
       </div>
     </div>
   );
-
-  return content;
 }

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/service-sidebar.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/service-sidebar.tsx
@@ -59,6 +59,9 @@ export function ServiceSidebar({
             setActiveTab(tab);
           }
         }}
+        getContentMode={function getContentMode(tab) {
+          return tab === "overview" || tab === "settings" ? "center" : "full";
+        }}
         icon={
           <img
             src={getServiceIcon(service) ?? FALLBACK_ICON}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/layout.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/layout.tsx
@@ -1,14 +1,28 @@
 "use client";
 
-import { useParams } from "next/navigation";
-import { useEffect, useState } from "react";
-import { TabNav } from "@/components/tab-nav";
+import { useParams, usePathname, useRouter } from "next/navigation";
+import { type SyntheticEvent, useEffect, useState } from "react";
 import { useDatabase } from "@/hooks/use-databases";
 import {
   DATABASE_LOGO_FALLBACK,
-  getDatabaseLogoAlt,
   getDatabaseLogoUrl,
 } from "@/lib/database-logo";
+import {
+  ResourceSidebar,
+  type ResourceSidebarTab,
+} from "../../../../_components/resource-sidebar";
+
+type DatabaseLayoutTab = "overview" | "branches" | "settings";
+
+function getActiveTab(pathname: string): DatabaseLayoutTab {
+  if (pathname.includes("/settings")) {
+    return "settings";
+  }
+  if (pathname.includes("/branches")) {
+    return "branches";
+  }
+  return "overview";
+}
 
 export default function DatabaseDetailLayout({
   children,
@@ -16,9 +30,13 @@ export default function DatabaseDetailLayout({
   children: React.ReactNode;
 }) {
   const params = useParams();
+  const pathname = usePathname();
+  const router = useRouter();
   const projectId = params.id as string;
   const envId = params.envId as string;
   const databaseId = params.databaseId as string;
+  const basePath = `/projects/${projectId}/environments/${envId}/databases/${databaseId}`;
+  const activeTab = getActiveTab(pathname);
   const { data: database } = useDatabase(databaseId);
   const [logoSrc, setLogoSrc] = useState(DATABASE_LOGO_FALLBACK);
 
@@ -33,46 +51,72 @@ export default function DatabaseDetailLayout({
     [database],
   );
 
-  function handleLogoError() {
+  function handleLogoError(event: SyntheticEvent<HTMLImageElement>) {
     if (logoSrc === DATABASE_LOGO_FALLBACK) {
       return;
     }
+    event.currentTarget.src = DATABASE_LOGO_FALLBACK;
     setLogoSrc(DATABASE_LOGO_FALLBACK);
   }
 
-  const tabs = [
+  const tabs: ResourceSidebarTab<DatabaseLayoutTab>[] = [
     {
-      label: database?.engine === "postgres" ? "Branches" : "Instances",
-      href: `/projects/${projectId}/environments/${envId}/databases/${databaseId}/branches`,
+      id: "overview",
+      label: "Overview",
     },
     {
+      id: "branches",
+      label: database?.engine === "postgres" ? "Branches" : "Instances",
+    },
+    {
+      id: "settings",
       label: "Settings",
-      href: `/projects/${projectId}/environments/${envId}/databases/${databaseId}/settings`,
     },
   ];
 
+  function handleTabChange(tab: DatabaseLayoutTab) {
+    switch (tab) {
+      case "overview":
+        router.push(basePath);
+        return;
+      case "branches":
+        router.push(`${basePath}/branches`);
+        return;
+      case "settings":
+        router.push(`${basePath}/settings`);
+        return;
+    }
+  }
+
+  function handleClose() {
+    router.push(`/projects/${projectId}/environments/${envId}`);
+  }
+
   return (
-    <div className="space-y-6">
-      <div className="flex items-center gap-3 px-1">
-        <div className="flex h-9 w-9 items-center justify-center rounded-lg border border-neutral-800 bg-neutral-900">
+    <div className="h-full min-h-0 overflow-hidden">
+      <ResourceSidebar
+        isOpen
+        onClose={handleClose}
+        title={database?.name ?? "Database"}
+        tabs={tabs}
+        activeTab={activeTab}
+        onTabChange={handleTabChange}
+        contentMode={
+          activeTab === "overview" || activeTab === "settings"
+            ? "center"
+            : "full"
+        }
+        icon={
           <img
             src={logoSrc}
-            alt={getDatabaseLogoAlt(database?.engine ?? "postgres")}
-            className="h-5 w-5 object-contain"
+            alt=""
+            className="h-4 w-4 object-contain"
             onError={handleLogoError}
           />
-        </div>
-        <div className="min-w-0">
-          <p className="truncate text-sm font-medium text-neutral-100">
-            {database?.name ?? "Database"}
-          </p>
-          <p className="text-xs text-neutral-500">
-            {database?.engine === "mysql" ? "MySQL" : "PostgreSQL"}
-          </p>
-        </div>
-      </div>
-      <TabNav tabs={tabs} layoutId="database-tabs" />
-      <div>{children}</div>
+        }
+      >
+        {children}
+      </ResourceSidebar>
     </div>
   );
 }

--- a/apps/app/src/components/environment-picker.tsx
+++ b/apps/app/src/components/environment-picker.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -34,44 +33,51 @@ export function EnvironmentPicker({
   onSelect,
   onCreateNew,
 }: EnvironmentPickerProps) {
-  const currentEnv = environments.find((e) => e.id === currentEnvId);
+  const currentEnv = environments.find(function byId(environment) {
+    return environment.id === currentEnvId;
+  });
   const currentName = currentEnv?.name ?? "Select environment";
 
   return (
-    <div className="inline-flex items-center gap-1">
-      <Link
-        href={textHref}
-        className="truncate text-sm text-neutral-100 outline-none transition-colors hover:text-neutral-300"
-      >
-        {currentName}
-      </Link>
+    <DropdownMenu>
+      <div className="flex w-full items-center gap-1">
+        <Link
+          href={textHref}
+          className="flex h-8 min-w-0 flex-1 items-center rounded-md border border-transparent px-2 text-sm text-neutral-100 outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-900"
+        >
+          <span className="truncate">{currentName}</span>
+        </Link>
 
-      <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded text-neutral-400 outline-none transition-colors hover:bg-neutral-800 hover:text-neutral-100"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-400 outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-100 data-[state=open]:border-neutral-800 data-[state=open]:bg-neutral-900 data-[state=open]:text-neutral-100"
             aria-label="Switch environment"
           >
             <ChevronsUpDown className="h-3.5 w-3.5" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-48">
-          <DropdownMenuLabel>Environments</DropdownMenuLabel>
-          <DropdownMenuRadioGroup value={currentEnvId} onValueChange={onSelect}>
-            {environments.map((env) => (
-              <DropdownMenuRadioItem key={env.id} value={env.id}>
-                {env.name}
+      </div>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuRadioGroup value={currentEnvId} onValueChange={onSelect}>
+          {environments.map(function renderEnvironment(environment) {
+            return (
+              <DropdownMenuRadioItem
+                key={environment.id}
+                value={environment.id}
+                className="w-full"
+              >
+                {environment.name}
               </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={onCreateNew}>
-            <Plus className="mr-2 h-4 w-4" />
-            New Environment
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+            );
+          })}
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onCreateNew}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Environment
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/apps/app/src/components/project-picker.tsx
+++ b/apps/app/src/components/project-picker.tsx
@@ -6,7 +6,6 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuLabel,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSeparator,
@@ -36,43 +35,48 @@ export function ProjectPicker({
   onCreateNew,
 }: ProjectPickerProps) {
   return (
-    <div className="inline-flex items-center gap-1">
-      <Link
-        href={textHref}
-        className="truncate text-sm text-neutral-100 outline-none transition-colors hover:text-neutral-300"
-      >
-        {currentProjectName}
-      </Link>
+    <DropdownMenu>
+      <div className="flex w-full items-center gap-1">
+        <Link
+          href={textHref}
+          className="flex h-8 min-w-0 flex-1 items-center rounded-md border border-transparent px-2 text-sm text-neutral-100 outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-900"
+        >
+          <span className="truncate">{currentProjectName}</span>
+        </Link>
 
-      <DropdownMenu>
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className="inline-flex h-8 w-8 items-center justify-center rounded text-neutral-400 outline-none transition-colors hover:bg-neutral-800 hover:text-neutral-100"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-transparent text-neutral-400 outline-none transition-colors hover:border-neutral-800 hover:bg-neutral-900 hover:text-neutral-100 data-[state=open]:border-neutral-800 data-[state=open]:bg-neutral-900 data-[state=open]:text-neutral-100"
             aria-label="Switch project"
           >
             <ChevronsUpDown className="h-3.5 w-3.5" />
           </button>
         </DropdownMenuTrigger>
-        <DropdownMenuContent align="start" className="min-w-48">
-          <DropdownMenuLabel>Projects</DropdownMenuLabel>
-          <DropdownMenuRadioGroup
-            value={currentProjectId}
-            onValueChange={onSelect}
-          >
-            {projects.map((project) => (
-              <DropdownMenuRadioItem key={project.id} value={project.id}>
+      </div>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuRadioGroup
+          value={currentProjectId}
+          onValueChange={onSelect}
+        >
+          {projects.map(function renderProject(project) {
+            return (
+              <DropdownMenuRadioItem
+                key={project.id}
+                value={project.id}
+                className="w-full"
+              >
                 {project.name}
               </DropdownMenuRadioItem>
-            ))}
-          </DropdownMenuRadioGroup>
-          <DropdownMenuSeparator />
-          <DropdownMenuItem onSelect={onCreateNew}>
-            <Plus className="mr-2 h-4 w-4" />
-            New Project
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
-    </div>
+            );
+          })}
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={onCreateNew}>
+          <Plus className="mr-2 h-4 w-4" />
+          New Project
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Summary
- make project and environment pickers behave like split controls
- keep name click for navigation and use chevron for switching
- remove left-menu section clutter and align resource rows to one shared layout
- add service and database icons in left menu rows

## Testing
- bun run typecheck
- bun run lint
