### PR TITLE
feat(db): add branch ttl and scale-to-zero

### DIFF
--- a/apps/app/schema/017-branch-ttl-scale-to-zero.sql
+++ b/apps/app/schema/017-branch-ttl-scale-to-zero.sql
@@ -1,0 +1,11 @@
+ALTER TABLE database_targets ADD COLUMN ttl_value INTEGER;
+ALTER TABLE database_targets ADD COLUMN ttl_unit TEXT CHECK (ttl_unit IN ('hours', 'days'));
+ALTER TABLE database_targets ADD COLUMN scale_to_zero_minutes INTEGER;
+ALTER TABLE database_targets ADD COLUMN last_activity_at INTEGER;
+ALTER TABLE database_targets ADD COLUMN runtime_host_port INTEGER;
+
+CREATE INDEX idx_database_targets_scale_to_zero_minutes
+ON database_targets(scale_to_zero_minutes);
+
+CREATE INDEX idx_database_targets_ttl
+ON database_targets(ttl_value, ttl_unit);

--- a/apps/app/scripts/e2e/group-07-database.sh
+++ b/apps/app/scripts/e2e/group-07-database.sh
@@ -5,6 +5,38 @@ source "$SCRIPT_DIR/common.sh"
 
 log "=== Database Services ==="
 
+provider_ref_field() {
+  local provider_ref_json="$1"
+  local field="$2"
+  echo "$provider_ref_json" | jq -r --arg field "$field" '
+    def decode:
+      if type=="string" then (try (fromjson | decode) catch .) else . end;
+    (decode[$field] // empty)
+  '
+}
+
+wait_for_branch_status() {
+  local target_id="$1"
+  local expected_status="$2"
+  local attempts="$3"
+  local sleep_seconds="$4"
+  local current_status=""
+
+  for _ in $(seq 1 "$attempts"); do
+    local runtime_state
+    runtime_state=$(api "$BASE_URL/api/databases/$DB_ID/branches/$target_id/runtime")
+    current_status=$(json_get "$runtime_state" '.lifecycleStatus')
+    if [ "$current_status" = "$expected_status" ]; then
+      echo "$current_status"
+      return 0
+    fi
+    sleep "$sleep_seconds"
+  done
+
+  echo "$current_status"
+  return 1
+}
+
 log "Getting database templates..."
 TEMPLATES=$(api "$BASE_URL/api/templates/databases")
 POSTGRES_FOUND=$(json_get "$TEMPLATES" '.[] | select(.id == "postgres") | .id')
@@ -40,9 +72,9 @@ ATTACHED_TARGET_ID=$(json_get "$ATTACHMENTS" '.[] | select(.databaseId == "'"$DB
 log "Environment attached to main target"
 
 PROVIDER_REF_JSON=$(json_get "$DB_CREATE" '.target.providerRefJson')
-POSTGRES_USER=$(echo "$PROVIDER_REF_JSON" | jq -r 'def decode: if type=="string" then (try (fromjson | decode) catch .) else . end; (decode.username // empty)')
-POSTGRES_PASSWORD=$(echo "$PROVIDER_REF_JSON" | jq -r 'def decode: if type=="string" then (try (fromjson | decode) catch .) else . end; (decode.password // empty)')
-POSTGRES_DB=$(echo "$PROVIDER_REF_JSON" | jq -r 'def decode: if type=="string" then (try (fromjson | decode) catch .) else . end; (decode.database // empty)')
+POSTGRES_USER=$(provider_ref_field "$PROVIDER_REF_JSON" "username")
+POSTGRES_PASSWORD=$(provider_ref_field "$PROVIDER_REF_JSON" "password")
+POSTGRES_DB=$(provider_ref_field "$PROVIDER_REF_JSON" "database")
 [ -z "$POSTGRES_USER" ] && fail "username missing"
 [ -z "$POSTGRES_PASSWORD" ] && fail "password missing"
 [ -z "$POSTGRES_DB" ] && fail "database missing"
@@ -61,10 +93,75 @@ DEV_TARGET=$(api -X POST "$BASE_URL/api/databases/$DB_ID/targets" \
 DEV_TARGET_ID=$(require_field "$DEV_TARGET" '.id' "create dev target") || fail "Failed to create dev target: $DEV_TARGET"
 log "Created branch: $DEV_TARGET_ID"
 
+DEV_PROVIDER_REF_JSON=$(json_get "$DEV_TARGET" '.providerRefJson')
+DEV_POSTGRES_USER=$(provider_ref_field "$DEV_PROVIDER_REF_JSON" "username")
+DEV_POSTGRES_PASSWORD=$(provider_ref_field "$DEV_PROVIDER_REF_JSON" "password")
+DEV_POSTGRES_DB=$(provider_ref_field "$DEV_PROVIDER_REF_JSON" "database")
+[ -z "$DEV_POSTGRES_USER" ] && fail "dev username missing"
+[ -z "$DEV_POSTGRES_PASSWORD" ] && fail "dev password missing"
+[ -z "$DEV_POSTGRES_DB" ] && fail "dev database missing"
+
 log "Resetting branch from parent..."
 api -X POST "$BASE_URL/api/databases/$DB_ID/targets/$DEV_TARGET_ID/reset" \
   -d '{"sourceTargetName":"main"}' > /dev/null
 log "Branch reset complete"
+
+DEV_RUNTIME_BEFORE=$(api "$BASE_URL/api/databases/$DB_ID/branches/$DEV_TARGET_ID/runtime")
+DEV_HOST_PORT_BEFORE=$(require_field "$DEV_RUNTIME_BEFORE" '.hostPort' "get dev hostPort before scale-to-zero") || fail "No branch host port before: $DEV_RUNTIME_BEFORE"
+
+log "Enabling scale-to-zero for branch..."
+api -X PATCH "$BASE_URL/api/databases/$DB_ID/branches/$DEV_TARGET_ID" \
+  -d '{"scaleToZeroMinutes":1}' > /dev/null
+
+DEV_RUNTIME_AFTER=$(api "$BASE_URL/api/databases/$DB_ID/branches/$DEV_TARGET_ID/runtime")
+DEV_HOST_PORT_AFTER=$(require_field "$DEV_RUNTIME_AFTER" '.hostPort' "get dev hostPort after scale-to-zero") || fail "No branch host port after: $DEV_RUNTIME_AFTER"
+DEV_RUNTIME_HOST_PORT=$(require_field "$DEV_RUNTIME_AFTER" '.runtimeHostPort' "get dev runtimeHostPort") || fail "No branch runtime host port after: $DEV_RUNTIME_AFTER"
+DEV_GATEWAY_ENABLED=$(json_get "$DEV_RUNTIME_AFTER" '.gatewayEnabled')
+[ "$DEV_HOST_PORT_BEFORE" = "$DEV_HOST_PORT_AFTER" ] || fail "Expected stable host port, before=$DEV_HOST_PORT_BEFORE after=$DEV_HOST_PORT_AFTER"
+[ "$DEV_GATEWAY_ENABLED" = "true" ] || fail "Expected gateway enabled, got: $DEV_GATEWAY_ENABLED"
+[ "$DEV_RUNTIME_HOST_PORT" != "$DEV_HOST_PORT_AFTER" ] || fail "Expected hidden runtime port to differ from stable host port"
+log "Scale-to-zero enabled on stable host port: $DEV_HOST_PORT_AFTER"
+
+log "Waiting for idle auto-stop..."
+DEV_STATUS=$(wait_for_branch_status "$DEV_TARGET_ID" "stopped" 36 5 || true)
+[ "$DEV_STATUS" = "stopped" ] || fail "Expected branch to auto-stop, last status: $DEV_STATUS"
+log "Branch auto-stopped after idle timeout"
+
+log "Connecting on same host port to auto-wake..."
+WAKE_RESULT=$(remote "PGPASSWORD='$DEV_POSTGRES_PASSWORD' timeout 90 psql \"host=localhost port=$DEV_HOST_PORT_AFTER user=$DEV_POSTGRES_USER dbname=$DEV_POSTGRES_DB sslmode=disable connect_timeout=70\" -tAc 'select 1'" 2>&1 || true)
+WAKE_VALUE=$(echo "$WAKE_RESULT" | tr -d '[:space:]')
+[ "$WAKE_VALUE" = "1" ] || fail "Expected wake query result 1, got: $WAKE_RESULT"
+log "Wake query succeeded on same host port"
+
+DEV_STATUS_AFTER_WAKE=$(wait_for_branch_status "$DEV_TARGET_ID" "active" 20 1 || true)
+[ "$DEV_STATUS_AFTER_WAKE" = "active" ] || fail "Expected branch active after wake, got: $DEV_STATUS_AFTER_WAKE"
+log "Branch woke after incoming connection"
+
+log "Creating detached branch for TTL delete..."
+TTL_TARGET=$(api -X POST "$BASE_URL/api/databases/$DB_ID/targets" \
+  -d '{"name":"ttl-dev","sourceTargetName":"main"}')
+TTL_TARGET_ID=$(require_field "$TTL_TARGET" '.id' "create ttl target") || fail "Failed to create ttl target: $TTL_TARGET"
+
+log "Enabling TTL on detached branch..."
+api -X PATCH "$BASE_URL/api/databases/$DB_ID/branches/$TTL_TARGET_ID" \
+  -d '{"ttlValue":1,"ttlUnit":"hours"}' > /dev/null
+
+TTL_CREATED_AT=$(( $(date +%s) * 1000 - 2 * 60 * 60 * 1000 ))
+remote "FROST_DB_PATH=\"$FROST_DATA_DIR/frost.db\" TTL_CREATED_AT=\"$TTL_CREATED_AT\" TTL_TARGET_ID=\"$TTL_TARGET_ID\" bun -e \"import { Database } from 'bun:sqlite'; const db = new Database(process.env.FROST_DB_PATH); db.query('UPDATE database_targets SET created_at = ? WHERE id = ?').run(Number(process.env.TTL_CREATED_AT), process.env.TTL_TARGET_ID); db.close();\""
+
+log "Waiting for TTL auto-delete..."
+TTL_EXISTS="$TTL_TARGET_ID"
+for _ in $(seq 1 36); do
+  TARGETS_NOW=$(api "$BASE_URL/api/databases/$DB_ID/targets")
+  TTL_EXISTS=$(json_get "$TARGETS_NOW" '.[] | select(.id == "'"$TTL_TARGET_ID"'") | .id')
+  if [ -z "$TTL_EXISTS" ] || [ "$TTL_EXISTS" = "null" ]; then
+    TTL_EXISTS=""
+    break
+  fi
+  sleep 5
+done
+[ -z "$TTL_EXISTS" ] || fail "Expected TTL target to be auto-deleted"
+log "TTL auto-delete verified"
 
 log "Deleting branch..."
 api -X DELETE "$BASE_URL/api/databases/$DB_ID/targets/$DEV_TARGET_ID" > /dev/null

--- a/apps/app/scripts/e2e/group-07-database.sh
+++ b/apps/app/scripts/e2e/group-07-database.sh
@@ -128,7 +128,7 @@ DEV_STATUS=$(wait_for_branch_status "$DEV_TARGET_ID" "stopped" 36 5 || true)
 log "Branch auto-stopped after idle timeout"
 
 log "Connecting on same host port to auto-wake..."
-WAKE_RESULT=$(remote "PGPASSWORD='$DEV_POSTGRES_PASSWORD' timeout 90 psql \"host=localhost port=$DEV_HOST_PORT_AFTER user=$DEV_POSTGRES_USER dbname=$DEV_POSTGRES_DB sslmode=disable connect_timeout=70\" -tAc 'select 1'" 2>&1 || true)
+WAKE_RESULT=$(remote "timeout 90 docker run --rm --network host -e PGPASSWORD='$DEV_POSTGRES_PASSWORD' postgres:17 psql \"host=127.0.0.1 port=$DEV_HOST_PORT_AFTER user=$DEV_POSTGRES_USER dbname=$DEV_POSTGRES_DB sslmode=disable connect_timeout=70\" -tAc 'select 1'" 2>&1 || true)
 WAKE_VALUE=$(echo "$WAKE_RESULT" | tr -d '[:space:]')
 [ "$WAKE_VALUE" = "1" ] || fail "Expected wake query result 1, got: $WAKE_RESULT"
 log "Wake query succeeded on same host port"

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
@@ -88,6 +88,9 @@ interface DatabaseBranchPanelProps {
     hostname?: string;
     memoryLimit?: string;
     cpuLimit?: number;
+    ttlValue?: number | null;
+    ttlUnit?: "hours" | "days" | null;
+    scaleToZeroMinutes?: number | null;
   }) => Promise<void>;
   isStartPending: boolean;
   isDeployPending: boolean;
@@ -181,6 +184,9 @@ export function DatabaseBranchPanel({
   const [draftHostname, setDraftHostname] = useState("");
   const [draftMemoryLimit, setDraftMemoryLimit] = useState("");
   const [draftCpuLimit, setDraftCpuLimit] = useState("none");
+  const [draftTtlValue, setDraftTtlValue] = useState("");
+  const [draftTtlUnit, setDraftTtlUnit] = useState<"hours" | "days">("hours");
+  const [draftScaleToZeroMinutes, setDraftScaleToZeroMinutes] = useState("");
   const [sqlInput, setSqlInput] = useState("select now();");
   const [sqlResult, setSqlResult] = useState<DatabaseTargetSqlResult | null>(
     null,
@@ -228,6 +234,9 @@ export function DatabaseBranchPanel({
         setDraftMemoryLimit("");
         setDraftCpuLimit("none");
         setDraftHostname(branch?.name ?? "");
+        setDraftTtlValue("");
+        setDraftTtlUnit("hours");
+        setDraftScaleToZeroMinutes("");
         return;
       }
       setDraftMemoryLimit(runtime.memoryLimit ?? "none");
@@ -235,6 +244,15 @@ export function DatabaseBranchPanel({
         runtime.cpuLimit !== null ? String(runtime.cpuLimit) : "none",
       );
       setDraftHostname(runtime.hostname);
+      setDraftTtlValue(
+        runtime.ttlValue !== null ? String(runtime.ttlValue) : "",
+      );
+      setDraftTtlUnit(runtime.ttlUnit ?? "hours");
+      setDraftScaleToZeroMinutes(
+        runtime.scaleToZeroMinutes !== null
+          ? String(runtime.scaleToZeroMinutes)
+          : "",
+      );
     },
     [runtime, branch?.name],
   );
@@ -315,6 +333,42 @@ export function DatabaseBranchPanel({
     hasRuntime && nextCpuLimit !== null && cpuLimitChanged;
   const canSaveMemoryLimit =
     hasRuntime && nextMemoryLimit !== null && memoryLimitChanged;
+  const nextTtlValue =
+    draftTtlValue.trim().length > 0 ? Number(draftTtlValue.trim()) : null;
+  const isValidTtlValue =
+    nextTtlValue === null ||
+    (Number.isInteger(nextTtlValue) &&
+      nextTtlValue >= 1 &&
+      nextTtlValue <= 8760);
+  const ttlChanged =
+    hasRuntime &&
+    (nextTtlValue !== runtime.ttlValue ||
+      (nextTtlValue !== null && draftTtlUnit !== runtime.ttlUnit));
+  const canSaveTtl = hasRuntime && isValidTtlValue && ttlChanged;
+  const nextScaleToZeroMinutes =
+    draftScaleToZeroMinutes.trim().length > 0
+      ? Number(draftScaleToZeroMinutes.trim())
+      : null;
+  const isValidScaleToZeroMinutes =
+    nextScaleToZeroMinutes === null ||
+    (Number.isInteger(nextScaleToZeroMinutes) &&
+      nextScaleToZeroMinutes >= 1 &&
+      nextScaleToZeroMinutes <= 24 * 60);
+  const scaleToZeroChanged =
+    hasRuntime && nextScaleToZeroMinutes !== runtime.scaleToZeroMinutes;
+  const branchAttachedToEnvironment = defaultEnvironmentNames.length > 0;
+  let scaleToZeroBlockedReason: string | null = null;
+  if (isMainBranch) {
+    scaleToZeroBlockedReason = "main cannot use scale to zero.";
+  } else if (branchAttachedToEnvironment) {
+    scaleToZeroBlockedReason =
+      "Detach this branch from environments before enabling scale to zero.";
+  }
+  const canSaveScaleToZero =
+    hasRuntime &&
+    isValidScaleToZeroMinutes &&
+    scaleToZeroChanged &&
+    (nextScaleToZeroMinutes === null || scaleToZeroBlockedReason === null);
   const filteredCpuOptions = CPU_OPTIONS.filter(
     (opt) => !opt.minCpus || (hostResources?.cpus ?? 0) >= opt.minCpus,
   );
@@ -385,6 +439,9 @@ export function DatabaseBranchPanel({
       hostname?: string;
       memoryLimit?: string;
       cpuLimit?: number;
+      ttlValue?: number | null;
+      ttlUnit?: "hours" | "days" | null;
+      scaleToZeroMinutes?: number | null;
     },
     successMessage: string,
   ) {
@@ -417,6 +474,27 @@ export function DatabaseBranchPanel({
     await saveSettingsWithToast(
       { memoryLimit: nextMemoryLimit ?? undefined },
       `${runtimeUnitCapitalized} memory limit saved`,
+    );
+  }
+
+  async function handleSaveTtl() {
+    await saveSettingsWithToast(
+      {
+        ttlValue: nextTtlValue,
+        ttlUnit: nextTtlValue === null ? null : draftTtlUnit,
+      },
+      nextTtlValue === null
+        ? `${runtimeUnitCapitalized} TTL cleared`
+        : `${runtimeUnitCapitalized} TTL saved`,
+    );
+  }
+
+  async function handleSaveScaleToZero() {
+    await saveSettingsWithToast(
+      { scaleToZeroMinutes: nextScaleToZeroMinutes },
+      nextScaleToZeroMinutes === null
+        ? `${runtimeUnitCapitalized} scale to zero disabled`
+        : `${runtimeUnitCapitalized} scale to zero saved`,
     );
   }
 
@@ -484,9 +562,21 @@ export function DatabaseBranchPanel({
                       Created: {getTimeAgo(new Date(branch.createdAt))}
                     </div>
                     {runtime && (
-                      <div className="text-neutral-500">
-                        Runtime id: {runtime.runtimeServiceId}
-                      </div>
+                      <>
+                        <div className="text-neutral-500">
+                          Runtime id: {runtime.runtimeServiceId}
+                        </div>
+                        <div className="text-neutral-500">
+                          Scale to zero:{" "}
+                          {runtime.gatewayEnabled ? "enabled" : "disabled"}
+                        </div>
+                        <div className="text-neutral-500">
+                          Last activity:{" "}
+                          {runtime.lastActivityAt
+                            ? getTimeAgo(new Date(runtime.lastActivityAt))
+                            : "never"}
+                        </div>
+                      </>
                     )}
                   </CardContent>
                 </Card>
@@ -1114,6 +1204,115 @@ export function DatabaseBranchPanel({
                             ))}
                           </SelectContent>
                         </Select>
+                      </SettingCard>
+
+                      <SettingCard
+                        title="Branch TTL"
+                        description="Auto-delete this branch after a fixed age."
+                        onSubmit={handleSaveTtl}
+                        footerRight={
+                          <Button
+                            size="sm"
+                            type="submit"
+                            disabled={
+                              !canSaveTtl ||
+                              isSaveSettingsPending ||
+                              (isMainBranch && nextTtlValue !== null)
+                            }
+                          >
+                            {isSaveSettingsPending ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              "Save"
+                            )}
+                          </Button>
+                        }
+                      >
+                        <div className="flex items-center gap-2">
+                          <Input
+                            type="number"
+                            min={1}
+                            max={8760}
+                            value={draftTtlValue}
+                            onChange={(event) =>
+                              setDraftTtlValue(event.target.value)
+                            }
+                            placeholder="disabled"
+                            className="w-36 border-neutral-700 bg-neutral-800 text-neutral-100"
+                          />
+                          <Select
+                            value={draftTtlUnit}
+                            onValueChange={(value) =>
+                              setDraftTtlUnit(value as "hours" | "days")
+                            }
+                          >
+                            <SelectTrigger className="w-32">
+                              <SelectValue />
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value="hours">hours</SelectItem>
+                              <SelectItem value="days">days</SelectItem>
+                            </SelectContent>
+                          </Select>
+                        </div>
+                        {isMainBranch && nextTtlValue !== null && (
+                          <div className="mt-2 text-xs text-neutral-500">
+                            main cannot use TTL.
+                          </div>
+                        )}
+                        {!isValidTtlValue && (
+                          <div className="mt-2 text-xs text-neutral-500">
+                            Use a whole number between 1 and 8760.
+                          </div>
+                        )}
+                      </SettingCard>
+
+                      <SettingCard
+                        title="Scale To Zero"
+                        description="Auto-stop this branch after idle time."
+                        onSubmit={handleSaveScaleToZero}
+                        footerRight={
+                          <Button
+                            size="sm"
+                            type="submit"
+                            disabled={
+                              !canSaveScaleToZero || isSaveSettingsPending
+                            }
+                          >
+                            {isSaveSettingsPending ? (
+                              <Loader2 className="h-4 w-4 animate-spin" />
+                            ) : (
+                              "Save"
+                            )}
+                          </Button>
+                        }
+                      >
+                        <div className="flex items-center gap-2">
+                          <Input
+                            type="number"
+                            min={1}
+                            max={24 * 60}
+                            value={draftScaleToZeroMinutes}
+                            onChange={(event) =>
+                              setDraftScaleToZeroMinutes(event.target.value)
+                            }
+                            placeholder="disabled"
+                            className="w-40 border-neutral-700 bg-neutral-800 text-neutral-100"
+                          />
+                          <span className="text-sm text-neutral-500">
+                            minutes
+                          </span>
+                        </div>
+                        {scaleToZeroBlockedReason && (
+                          <div className="mt-2 text-xs text-neutral-500">
+                            {scaleToZeroBlockedReason}
+                          </div>
+                        )}
+                        {!isValidScaleToZeroMinutes && (
+                          <div className="mt-2 text-xs text-neutral-500">
+                            Use a whole number between 1 and 1440.
+                          </div>
+                        )}
                       </SettingCard>
                     </>
                   )}

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -34,6 +34,11 @@ export const databaseTargetSchema = z.object({
   runtimeServiceId: z.string(),
   lifecycleStatus: databaseTargetLifecycleSchema,
   providerRefJson: z.string(),
+  ttlValue: z.number().nullable(),
+  ttlUnit: z.enum(["hours", "days"]).nullable(),
+  scaleToZeroMinutes: z.number().nullable(),
+  lastActivityAt: z.number().nullable(),
+  runtimeHostPort: z.number().nullable(),
   createdAt: z.number(),
 });
 
@@ -69,11 +74,17 @@ const databaseTargetRuntimeSchema = z.object({
   lifecycleStatus: databaseTargetLifecycleSchema,
   containerName: z.string(),
   hostPort: z.number(),
+  runtimeHostPort: z.number(),
+  gatewayEnabled: z.boolean(),
   image: z.string(),
   port: z.number(),
   storageBackend: databaseStorageBackendSchema.nullable(),
   memoryLimit: z.string().nullable(),
   cpuLimit: z.number().nullable(),
+  ttlValue: z.number().nullable(),
+  ttlUnit: z.enum(["hours", "days"]).nullable(),
+  scaleToZeroMinutes: z.number().nullable(),
+  lastActivityAt: z.number().nullable(),
   createdAt: z.number(),
 });
 
@@ -358,6 +369,15 @@ export const databasesContract = {
           .nullable()
           .optional(),
         cpuLimit: z.number().min(0.1).max(64).nullable().optional(),
+        ttlValue: z.number().int().min(1).max(8760).nullable().optional(),
+        ttlUnit: z.enum(["hours", "days"]).nullable().optional(),
+        scaleToZeroMinutes: z
+          .number()
+          .int()
+          .min(1)
+          .max(24 * 60)
+          .nullable()
+          .optional(),
       }),
     )
     .output(databaseTargetRuntimeSchema),
@@ -443,6 +463,15 @@ export const databasesContract = {
           .nullable()
           .optional(),
         cpuLimit: z.number().min(0.1).max(64).nullable().optional(),
+        ttlValue: z.number().int().min(1).max(8760).nullable().optional(),
+        ttlUnit: z.enum(["hours", "days"]).nullable().optional(),
+        scaleToZeroMinutes: z
+          .number()
+          .int()
+          .min(1)
+          .max(24 * 60)
+          .nullable()
+          .optional(),
       }),
     )
     .output(databaseTargetRuntimeSchema),

--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -40,6 +40,18 @@ export async function register() {
     startPostgresBackupScheduler();
     console.log("[startup] postgres backup scheduler: started");
 
+    const { restoreDatabaseTargetGateways } = await import(
+      "./lib/database-runtime"
+    );
+    await restoreDatabaseTargetGateways();
+    console.log("[startup] database target gateways: restored");
+
+    const { startDatabaseTargetPolicyScheduler } = await import(
+      "./lib/database-target-policy-scheduler"
+    );
+    startDatabaseTargetPolicyScheduler();
+    console.log("[startup] database target policy scheduler: started");
+
     const { syncCaddyConfig } = await import("./lib/domains");
     try {
       const result = await syncCaddyConfig();

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -8,6 +8,10 @@ import {
   type DatabaseProvider,
   normalizeDatabaseProvider,
 } from "./database-provider";
+import {
+  startDatabaseTargetGateway,
+  stopDatabaseTargetGateway,
+} from "./database-target-gateway";
 import { db } from "./db";
 import type {
   Databases,
@@ -67,6 +71,7 @@ export type DatabaseTargetDeploymentStatus = "running" | "failed" | "stopped";
 interface ProviderRef {
   containerName: string;
   hostPort: number;
+  runtimeHostPort?: number;
   username: string;
   password: string;
   database: string;
@@ -100,11 +105,17 @@ export interface DatabaseTargetRuntimeInfo {
   lifecycleStatus: DatabaseTargetLifecycle;
   containerName: string;
   hostPort: number;
+  runtimeHostPort: number;
+  gatewayEnabled: boolean;
   image: string;
   port: number;
   storageBackend: BranchStorageBackendName | null;
   memoryLimit: string | null;
   cpuLimit: number | null;
+  ttlValue: number | null;
+  ttlUnit: "hours" | "days" | null;
+  scaleToZeroMinutes: number | null;
+  lastActivityAt: number | null;
   createdAt: number;
 }
 
@@ -122,6 +133,9 @@ const TARGET_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/;
 const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 const MEMORY_LIMIT_PATTERN = /^\d+[kmg]$/i;
 const POSTGRES_QUERY_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
+const TARGET_ACTIVITY_WRITE_THROTTLE_MS = 5000;
+
+const targetActivityWriteAt = new Map<string, number>();
 
 function randomSecret(bytes = 24): string {
   return randomBytes(bytes).toString("base64url");
@@ -246,9 +260,16 @@ function parseProviderRef(json: string): ProviderRef {
   ) {
     throw new Error("Invalid provider reference");
   }
+  if (
+    value.runtimeHostPort !== undefined &&
+    typeof value.runtimeHostPort !== "number"
+  ) {
+    throw new Error("Invalid provider reference");
+  }
   return {
     containerName: value.containerName,
     hostPort: value.hostPort,
+    runtimeHostPort: value.runtimeHostPort,
     username: value.username,
     password: value.password,
     database: value.database,
@@ -276,6 +297,65 @@ function applyProviderRefStorage(
 ): void {
   providerRef.storageBackend = storage.storageBackend;
   providerRef.storageRef = storage.storageRef;
+}
+
+function getTargetRuntimeHostPort(
+  target: Pick<DatabaseTargets, "runtimeHostPort">,
+  providerRef: ProviderRef,
+): number {
+  if (target.runtimeHostPort !== null) {
+    return target.runtimeHostPort;
+  }
+  if (providerRef.runtimeHostPort !== undefined) {
+    return providerRef.runtimeHostPort;
+  }
+  return providerRef.hostPort;
+}
+
+function applyProviderRefRuntimePorts(input: {
+  target: Pick<DatabaseTargets, "runtimeHostPort">;
+  previousProviderRef: ProviderRef;
+  nextProviderRef: ProviderRef;
+}): void {
+  if (
+    input.target.runtimeHostPort === null &&
+    input.previousProviderRef.runtimeHostPort === undefined
+  ) {
+    input.nextProviderRef.runtimeHostPort = undefined;
+    return;
+  }
+
+  const runtimeHostPort = getTargetRuntimeHostPort(
+    input.target,
+    input.previousProviderRef,
+  );
+  input.nextProviderRef.hostPort = input.previousProviderRef.hostPort;
+  input.nextProviderRef.runtimeHostPort = runtimeHostPort;
+}
+
+async function setTargetActivityAt(
+  targetId: string,
+  activityAt: number,
+): Promise<void> {
+  await db
+    .updateTable("databaseTargets")
+    .set({ lastActivityAt: activityAt })
+    .where("id", "=", targetId)
+    .execute();
+}
+
+function queueTargetActivityWrite(targetId: string): void {
+  const now = Date.now();
+  const lastWriteAt = targetActivityWriteAt.get(targetId) ?? 0;
+  if (now - lastWriteAt < TARGET_ACTIVITY_WRITE_THROTTLE_MS) {
+    return;
+  }
+  targetActivityWriteAt.set(targetId, now);
+  setTargetActivityAt(targetId, now).catch(function onError() {});
+}
+
+function clearTargetActivityWrite(targetId: string): void {
+  targetActivityWriteAt.delete(targetId);
 }
 
 async function recordTargetDeployment(input: {
@@ -557,6 +637,7 @@ async function recreateTargetRuntime(input: {
   database: Selectable<Databases>;
   target: Selectable<DatabaseTargets>;
   providerRef: ProviderRef;
+  fixedHostPort?: number;
 }): Promise<ProviderRef> {
   const storage =
     input.database.engine === "postgres"
@@ -573,7 +654,7 @@ async function recreateTargetRuntime(input: {
     runtimeServiceId: input.target.runtimeServiceId,
     engine: input.database.engine as DatabaseEngine,
     templateRef: input.providerRef,
-    fixedHostPort: input.providerRef.hostPort,
+    fixedHostPort: input.fixedHostPort ?? input.providerRef.hostPort,
     storageMountPath,
   });
 
@@ -763,6 +844,68 @@ async function reconnectPostgresDatabaseAttachments(
   }
 }
 
+function isScaleToZeroEnabled(
+  target: Pick<DatabaseTargets, "scaleToZeroMinutes">,
+): boolean {
+  return target.scaleToZeroMinutes !== null;
+}
+
+async function ensureTargetGateway(targetId: string): Promise<void> {
+  const target = await getTargetById(targetId);
+  const providerRef = parseProviderRef(target.providerRefJson);
+
+  if (!isScaleToZeroEnabled(target)) {
+    await stopDatabaseTargetGateway(target.id);
+    return;
+  }
+
+  if (target.runtimeHostPort === null) {
+    throw new Error("Scale to zero target is missing runtime host port");
+  }
+
+  await startDatabaseTargetGateway({
+    targetId: target.id,
+    listenPort: providerRef.hostPort,
+    ensureRunning: async function ensureRunning() {
+      let current = await getTargetById(target.id);
+      if (current.lifecycleStatus !== "active") {
+        current = await startDatabaseTarget({
+          databaseId: current.databaseId,
+          targetId: current.id,
+        });
+      }
+      const currentProviderRef = parseProviderRef(current.providerRefJson);
+      return getTargetRuntimeHostPort(current, currentProviderRef);
+    },
+    onActivity: function onActivity() {
+      queueTargetActivityWrite(target.id);
+    },
+  });
+}
+
+export async function restoreDatabaseTargetGateways(): Promise<void> {
+  const targets = await db
+    .selectFrom("databaseTargets")
+    .innerJoin("databases", "databases.id", "databaseTargets.databaseId")
+    .selectAll("databaseTargets")
+    .where("databaseTargets.scaleToZeroMinutes", "is not", null)
+    .where("databaseTargets.kind", "=", "branch")
+    .where("databaseTargets.name", "!=", "main")
+    .where("databases.engine", "=", "postgres")
+    .execute();
+
+  for (const target of targets) {
+    try {
+      await ensureTargetGateway(target.id);
+    } catch (error) {
+      console.error("[database-runtime] Failed to restore target gateway", {
+        targetId: target.id,
+        error,
+      });
+    }
+  }
+}
+
 function buildConnectionString(
   database: Selectable<Databases>,
   providerRef: ProviderRef,
@@ -877,6 +1020,11 @@ export async function createDatabase(input: {
         runtimeServiceId,
         lifecycleStatus: "active",
         providerRefJson: toProviderRefJson(providerRef),
+        ttlValue: null,
+        ttlUnit: null,
+        scaleToZeroMinutes: null,
+        lastActivityAt: createdAt,
+        runtimeHostPort: null,
         createdAt,
       })
       .execute();
@@ -1025,6 +1173,11 @@ export async function createDatabaseTarget(input: {
         runtimeServiceId,
         lifecycleStatus: "active",
         providerRefJson: toProviderRefJson(providerRef),
+        ttlValue: null,
+        ttlUnit: null,
+        scaleToZeroMinutes: null,
+        lastActivityAt: createdAt,
+        runtimeHostPort: null,
         createdAt,
       })
       .execute();
@@ -1157,7 +1310,7 @@ export async function resetDatabaseTarget(input: {
       runtimeServiceId: target.runtimeServiceId,
       engine: "postgres",
       templateRef,
-      fixedHostPort: currentRef.hostPort,
+      fixedHostPort: getTargetRuntimeHostPort(target, currentRef),
       storageMountPath: liveMountPath,
     });
   } catch (error) {
@@ -1178,6 +1331,11 @@ export async function resetDatabaseTarget(input: {
   }
 
   applyProviderRefStorage(nextRef, currentStorage);
+  applyProviderRefRuntimePorts({
+    target,
+    previousProviderRef: currentRef,
+    nextProviderRef: nextRef,
+  });
 
   await db
     .updateTable("databaseTargets")
@@ -1185,6 +1343,7 @@ export async function resetDatabaseTarget(input: {
       sourceTargetId: sourceTarget.id,
       lifecycleStatus: "active",
       providerRefJson: toProviderRefJson(nextRef),
+      lastActivityAt: Date.now(),
     })
     .where("id", "=", target.id)
     .execute();
@@ -1197,6 +1356,7 @@ export async function resetDatabaseTarget(input: {
   });
 
   const updated = await getTargetById(target.id);
+  await ensureTargetGateway(updated.id);
   await reconnectTargetAttachments(database, updated);
   return updated;
 }
@@ -1210,10 +1370,17 @@ export async function startDatabaseTarget(input: {
     input.targetId,
   );
   const providerRef = parseProviderRef(target.providerRefJson);
+  const runtimeHostPort = getTargetRuntimeHostPort(target, providerRef);
   const nextRef = await recreateTargetRuntime({
     database,
     target,
     providerRef,
+    fixedHostPort: runtimeHostPort,
+  });
+  applyProviderRefRuntimePorts({
+    target,
+    previousProviderRef: providerRef,
+    nextProviderRef: nextRef,
   });
 
   await db
@@ -1221,6 +1388,7 @@ export async function startDatabaseTarget(input: {
     .set({
       lifecycleStatus: "active",
       providerRefJson: toProviderRefJson(nextRef),
+      lastActivityAt: Date.now(),
     })
     .where("id", "=", target.id)
     .execute();
@@ -1233,6 +1401,7 @@ export async function startDatabaseTarget(input: {
   });
 
   const updated = await getTargetById(target.id);
+  await ensureTargetGateway(updated.id);
   await reconnectTargetAttachments(database, updated);
   return updated;
 }
@@ -1261,6 +1430,7 @@ export async function stopDatabaseTarget(input: {
     message: "Target stopped",
   });
 
+  clearTargetActivityWrite(target.id);
   return getTargetById(target.id);
 }
 
@@ -1287,6 +1457,8 @@ export async function deleteDatabaseTarget(input: {
     throw new Error("Target is attached to one or more environments");
   }
 
+  await stopDatabaseTargetGateway(target.id);
+  clearTargetActivityWrite(target.id);
   const providerRef = parseProviderRef(target.providerRefJson);
   await stopContainer(providerRef.containerName);
   if (database.engine === "postgres") {
@@ -1304,6 +1476,8 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
     .execute();
 
   for (const target of targets) {
+    await stopDatabaseTargetGateway(target.id);
+    clearTargetActivityWrite(target.id);
     const providerRef = parseProviderRef(target.providerRefJson);
     await stopContainer(providerRef.containerName);
     if (database.engine === "postgres") {
@@ -1340,6 +1514,10 @@ export async function putEnvironmentAttachment(input: {
 
   if (target.databaseId !== database.id) {
     throw new Error("Target does not belong to the database");
+  }
+
+  if (target.scaleToZeroMinutes !== null) {
+    throw new Error("Cannot attach a target while scale to zero is enabled");
   }
 
   if (
@@ -1474,6 +1652,8 @@ export async function deleteEnvironmentAttachment(input: {
       return;
     }
 
+    await stopDatabaseTargetGateway(target.id);
+    clearTargetActivityWrite(target.id);
     const providerRef = parseProviderRef(target.providerRefJson);
     await stopContainer(providerRef.containerName);
     await removePostgresStorage(getPostgresStorageMetadata(providerRef));
@@ -1510,6 +1690,8 @@ export async function deleteEnvironmentAttachment(input: {
     return;
   }
 
+  await stopDatabaseTargetGateway(target.id);
+  clearTargetActivityWrite(target.id);
   const providerRef = parseProviderRef(target.providerRefJson);
   await stopContainer(providerRef.containerName);
   await db.deleteFrom("databaseTargets").where("id", "=", target.id).execute();
@@ -1613,10 +1795,17 @@ export async function deployDatabaseTarget(
   const providerRef = parseProviderRef(target.providerRefJson);
 
   try {
+    const runtimeHostPort = getTargetRuntimeHostPort(target, providerRef);
     const nextRef = await recreateTargetRuntime({
       database,
       target,
       providerRef,
+      fixedHostPort: runtimeHostPort,
+    });
+    applyProviderRefRuntimePorts({
+      target,
+      previousProviderRef: providerRef,
+      nextProviderRef: nextRef,
     });
 
     await db
@@ -1624,9 +1813,12 @@ export async function deployDatabaseTarget(
       .set({
         lifecycleStatus: "active",
         providerRefJson: toProviderRefJson(nextRef),
+        lastActivityAt: Date.now(),
       })
       .where("id", "=", target.id)
       .execute();
+
+    await ensureTargetGateway(target.id);
 
     return recordTargetDeployment({
       targetId: target.id,
@@ -1666,11 +1858,17 @@ export async function getDatabaseTargetRuntime(
     lifecycleStatus: target.lifecycleStatus as DatabaseTargetLifecycle,
     containerName: providerRef.containerName,
     hostPort: providerRef.hostPort,
+    runtimeHostPort: getTargetRuntimeHostPort(target, providerRef),
+    gatewayEnabled: isScaleToZeroEnabled(target),
     image: providerRef.image,
     port: providerRef.port,
     storageBackend: providerRef.storageBackend ?? null,
     memoryLimit: providerRef.memoryLimit,
     cpuLimit: providerRef.cpuLimit,
+    ttlValue: target.ttlValue,
+    ttlUnit: target.ttlUnit,
+    scaleToZeroMinutes: target.scaleToZeroMinutes,
+    lastActivityAt: target.lastActivityAt,
     createdAt: target.createdAt,
   };
 }
@@ -1749,6 +1947,8 @@ export async function runPostgresTargetSql(input: {
             : "SQL query failed";
 
     throw new Error(message);
+  } finally {
+    queueTargetActivityWrite(target.id);
   }
 }
 
@@ -1757,10 +1957,14 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
   name?: string;
   hostname?: string;
   lifecycleStatus?: "active" | "stopped";
+  ttlValue?: number | null;
+  ttlUnit?: "hours" | "days" | null;
+  scaleToZeroMinutes?: number | null;
   memoryLimit?: string | null;
   cpuLimit?: number | null;
 }): Promise<DatabaseTargetRuntimeInfo> {
   const target = await getTargetById(input.targetId);
+  const database = await getDatabaseById(target.databaseId);
   let nextName = target.name;
   let nextHostname = target.hostname;
 
@@ -1819,6 +2023,52 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
       .execute();
   }
 
+  let nextTtlValue = target.ttlValue;
+  let nextTtlUnit = target.ttlUnit;
+
+  if (input.ttlValue !== undefined) {
+    nextTtlValue = input.ttlValue;
+  }
+  if (input.ttlUnit !== undefined) {
+    nextTtlUnit = input.ttlUnit;
+  }
+  if (input.ttlValue === null || input.ttlUnit === null) {
+    nextTtlValue = null;
+    nextTtlUnit = null;
+  }
+  if (
+    (nextTtlValue === null && nextTtlUnit !== null) ||
+    (nextTtlValue !== null && nextTtlUnit === null)
+  ) {
+    throw new Error("TTL value and unit must be set together");
+  }
+  if (nextTtlValue !== null && target.name === "main") {
+    throw new Error("main cannot use TTL");
+  }
+  if (
+    nextTtlValue !== null &&
+    (database.engine !== "postgres" || target.kind !== "branch")
+  ) {
+    throw new Error("TTL is only available for postgres branches");
+  }
+
+  let nextScaleToZeroMinutes = target.scaleToZeroMinutes;
+  if (input.scaleToZeroMinutes !== undefined) {
+    nextScaleToZeroMinutes = input.scaleToZeroMinutes;
+  }
+  if (nextScaleToZeroMinutes !== null && target.name === "main") {
+    throw new Error("main cannot use scale to zero");
+  }
+  if (
+    nextScaleToZeroMinutes !== null &&
+    (database.engine !== "postgres" || target.kind !== "branch")
+  ) {
+    throw new Error("Scale to zero is only available for postgres branches");
+  }
+
+  const scaleToZeroChanged =
+    nextScaleToZeroMinutes !== target.scaleToZeroMinutes;
+
   if (input.memoryLimit === null || input.cpuLimit === null) {
     throw new Error("Clearing branch limits is not supported yet");
   }
@@ -1853,6 +2103,120 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
       .execute();
   }
 
+  if (scaleToZeroChanged) {
+    const currentProviderRef = parseProviderRef(
+      (await getTargetById(target.id)).providerRefJson,
+    );
+    if (nextScaleToZeroMinutes !== null) {
+      const attachment = await db
+        .selectFrom("environmentDatabaseAttachments")
+        .select("id")
+        .where("targetId", "=", target.id)
+        .executeTakeFirst();
+      if (attachment) {
+        throw new Error(
+          "Scale to zero only works for detached branches right now",
+        );
+      }
+
+      let runtimeHostPort = target.runtimeHostPort;
+      let nextProviderRef = currentProviderRef;
+
+      if (runtimeHostPort === null) {
+        runtimeHostPort = await getAvailablePort(
+          10000,
+          20000,
+          new Set([currentProviderRef.hostPort]),
+        );
+      }
+
+      if (target.lifecycleStatus === "active") {
+        const recreated = await recreateTargetRuntime({
+          database,
+          target,
+          providerRef: currentProviderRef,
+          fixedHostPort: runtimeHostPort,
+        });
+        recreated.hostPort = currentProviderRef.hostPort;
+        recreated.runtimeHostPort = runtimeHostPort;
+        nextProviderRef = recreated;
+      } else {
+        nextProviderRef = {
+          ...currentProviderRef,
+          runtimeHostPort,
+        };
+      }
+
+      await db
+        .updateTable("databaseTargets")
+        .set({
+          providerRefJson: toProviderRefJson(nextProviderRef),
+          runtimeHostPort,
+          scaleToZeroMinutes: nextScaleToZeroMinutes,
+          lastActivityAt: Date.now(),
+        })
+        .where("id", "=", target.id)
+        .execute();
+
+      await ensureTargetGateway(target.id);
+    } else {
+      await stopDatabaseTargetGateway(target.id);
+      clearTargetActivityWrite(target.id);
+
+      let nextProviderRef = currentProviderRef;
+      if (target.lifecycleStatus === "active") {
+        const recreated = await recreateTargetRuntime({
+          database,
+          target: {
+            ...target,
+            runtimeHostPort: null,
+          },
+          providerRef: currentProviderRef,
+          fixedHostPort: currentProviderRef.hostPort,
+        });
+        recreated.runtimeHostPort = undefined;
+        nextProviderRef = recreated;
+      } else {
+        nextProviderRef = {
+          ...currentProviderRef,
+          runtimeHostPort: undefined,
+        };
+      }
+
+      await db
+        .updateTable("databaseTargets")
+        .set({
+          providerRefJson: toProviderRefJson(nextProviderRef),
+          runtimeHostPort: null,
+          scaleToZeroMinutes: null,
+        })
+        .where("id", "=", target.id)
+        .execute();
+    }
+  } else if (nextScaleToZeroMinutes !== null) {
+    await db
+      .updateTable("databaseTargets")
+      .set({ scaleToZeroMinutes: nextScaleToZeroMinutes })
+      .where("id", "=", target.id)
+      .execute();
+  }
+
+  if (
+    nextTtlValue !== target.ttlValue ||
+    nextTtlUnit !== target.ttlUnit ||
+    nextScaleToZeroMinutes !== target.scaleToZeroMinutes
+  ) {
+    await db
+      .updateTable("databaseTargets")
+      .set({
+        ttlValue: nextTtlValue,
+        ttlUnit: nextTtlUnit,
+        scaleToZeroMinutes: nextScaleToZeroMinutes,
+      })
+      .where("id", "=", target.id)
+      .execute();
+  }
+
   if (input.lifecycleStatus === "active") {
     await startDatabaseTarget({
       databaseId: target.databaseId,
@@ -1868,7 +2232,6 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
   }
 
   if (nameChanged || hostnameChanged) {
-    const database = await getDatabaseById(target.databaseId);
     if (database.engine === "postgres") {
       await reconnectPostgresDatabaseAttachments(database);
     }

--- a/apps/app/src/lib/database-target-gateway.test.ts
+++ b/apps/app/src/lib/database-target-gateway.test.ts
@@ -1,0 +1,123 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  createConnection,
+  createServer,
+  type Server,
+  type Socket,
+} from "node:net";
+import {
+  getDatabaseTargetGatewayActiveConnections,
+  startDatabaseTargetGateway,
+  stopAllDatabaseTargetGateways,
+  stopDatabaseTargetGateway,
+} from "./database-target-gateway";
+
+const servers: Server[] = [];
+
+function listenServer(server: Server, port: number): Promise<number> {
+  return new Promise(function listenServerPromise(resolve, reject) {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", function onListen() {
+      server.off("error", reject);
+      const address = server.address();
+      if (!address || typeof address === "string") {
+        reject(new Error("Server did not bind to a TCP port"));
+        return;
+      }
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise(function closeServerPromise(resolve) {
+    if (!server.listening) {
+      resolve();
+      return;
+    }
+    server.close(function onClose() {
+      resolve();
+    });
+  });
+}
+
+function connectClient(port: number): Promise<Socket> {
+  return new Promise(function connectClientPromise(resolve, reject) {
+    const socket = createConnection({ host: "127.0.0.1", port });
+    socket.once("connect", function onConnect() {
+      resolve(socket);
+    });
+    socket.once("error", reject);
+  });
+}
+
+function waitForData(socket: Socket): Promise<Buffer> {
+  return new Promise(function waitForDataPromise(resolve, reject) {
+    socket.once("data", function onData(chunk: Buffer) {
+      resolve(chunk);
+    });
+    socket.once("error", reject);
+  });
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise(function waitPromise(resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+afterEach(async function cleanup() {
+  await stopAllDatabaseTargetGateways();
+  while (servers.length > 0) {
+    const server = servers.pop();
+    if (server) {
+      await closeServer(server);
+    }
+  }
+});
+
+describe("database target gateway", function describeGateway() {
+  test("buffers first bytes and forwards traffic", async function testForwarding() {
+    let activityEvents = 0;
+
+    const upstreamServer = createServer(function onConnection(socket) {
+      socket.on("data", function onSocketData(chunk) {
+        socket.write(chunk);
+      });
+    });
+    servers.push(upstreamServer);
+    const upstreamPort = await listenServer(upstreamServer, 0);
+
+    const gatewayProbe = createServer();
+    const gatewayPort = await listenServer(gatewayProbe, 0);
+    await closeServer(gatewayProbe);
+
+    await startDatabaseTargetGateway({
+      targetId: "dbt_test",
+      listenPort: gatewayPort,
+      ensureRunning: async function ensureRunning() {
+        return upstreamPort;
+      },
+      onActivity: function onActivity() {
+        activityEvents += 1;
+      },
+    });
+
+    const client = await connectClient(gatewayPort);
+    client.write("hello");
+
+    const response = await waitForData(client);
+    expect(response.toString()).toBe("hello");
+    expect(getDatabaseTargetGatewayActiveConnections("dbt_test")).toBe(1);
+    expect(activityEvents).toBeGreaterThan(0);
+
+    client.end();
+    await wait(30);
+    expect(getDatabaseTargetGatewayActiveConnections("dbt_test")).toBe(0);
+  });
+
+  test("stop is safe when gateway does not exist", async function testStopMissing() {
+    await stopDatabaseTargetGateway("dbt_missing");
+    expect(getDatabaseTargetGatewayActiveConnections("dbt_missing")).toBe(0);
+  });
+});

--- a/apps/app/src/lib/database-target-gateway.ts
+++ b/apps/app/src/lib/database-target-gateway.ts
@@ -1,0 +1,305 @@
+import {
+  createConnection,
+  createServer,
+  type Server,
+  type Socket,
+} from "node:net";
+
+const GATEWAY_START_TIMEOUT_MS = 60_000;
+const GATEWAY_BUFFER_LIMIT_BYTES = 1024 * 1024;
+
+interface DatabaseTargetGatewayConfig {
+  targetId: string;
+  listenPort: number;
+  ensureRunning: () => Promise<number>;
+  onActivity: () => void;
+}
+
+interface DatabaseTargetGatewayEntry {
+  targetId: string;
+  listenPort: number;
+  ensureRunning: () => Promise<number>;
+  onActivity: () => void;
+  server: Server;
+  sockets: Set<Socket>;
+  activeConnections: number;
+}
+
+const gatewayEntries = new Map<string, DatabaseTargetGatewayEntry>();
+
+function withTimeout<T>(
+  input: Promise<T>,
+  ms: number,
+  message: string,
+): Promise<T> {
+  return new Promise(function withTimeoutPromise(resolve, reject) {
+    const timeoutId = setTimeout(function onTimeout() {
+      reject(new Error(message));
+    }, ms);
+
+    input
+      .then(function onResolve(value) {
+        clearTimeout(timeoutId);
+        resolve(value);
+      })
+      .catch(function onReject(error) {
+        clearTimeout(timeoutId);
+        reject(error);
+      });
+  });
+}
+
+function waitForUpstreamConnection(port: number): Promise<Socket> {
+  return new Promise(function waitForUpstream(resolve, reject) {
+    const socket = createConnection({ host: "127.0.0.1", port });
+
+    const timeoutId = setTimeout(function onTimeout() {
+      socket.destroy();
+      reject(
+        new Error("Gateway timed out while connecting to postgres runtime"),
+      );
+    }, GATEWAY_START_TIMEOUT_MS);
+
+    socket.once("connect", function onConnect() {
+      clearTimeout(timeoutId);
+      resolve(socket);
+    });
+
+    socket.once("error", function onError(error) {
+      clearTimeout(timeoutId);
+      reject(error);
+    });
+  });
+}
+
+function decreaseActiveConnections(entry: DatabaseTargetGatewayEntry): void {
+  if (entry.activeConnections <= 0) {
+    entry.activeConnections = 0;
+    return;
+  }
+  entry.activeConnections -= 1;
+}
+
+function handleGatewayConnection(
+  entry: DatabaseTargetGatewayEntry,
+  clientSocket: Socket,
+): void {
+  entry.sockets.add(clientSocket);
+  entry.activeConnections += 1;
+
+  let upstreamSocket: Socket | null = null;
+  let completed = false;
+  let bufferedBytes = 0;
+  const bufferedChunks: Buffer[] = [];
+
+  function cleanup(): void {
+    if (completed) {
+      return;
+    }
+    completed = true;
+
+    entry.sockets.delete(clientSocket);
+    if (upstreamSocket) {
+      entry.sockets.delete(upstreamSocket);
+    }
+    decreaseActiveConnections(entry);
+  }
+
+  function closeBoth(): void {
+    if (!clientSocket.destroyed) {
+      clientSocket.destroy();
+    }
+    if (upstreamSocket && !upstreamSocket.destroyed) {
+      upstreamSocket.destroy();
+    }
+  }
+
+  clientSocket.on("data", function onClientData(chunk: Buffer) {
+    entry.onActivity();
+
+    if (!upstreamSocket || upstreamSocket.destroyed) {
+      bufferedBytes += chunk.length;
+      if (bufferedBytes > GATEWAY_BUFFER_LIMIT_BYTES) {
+        closeBoth();
+        return;
+      }
+      bufferedChunks.push(Buffer.from(chunk));
+      return;
+    }
+
+    if (!upstreamSocket.write(chunk)) {
+      clientSocket.pause();
+    }
+  });
+
+  clientSocket.on("error", function onClientError() {
+    closeBoth();
+  });
+  clientSocket.on("end", function onClientEnd() {
+    if (upstreamSocket && !upstreamSocket.destroyed) {
+      upstreamSocket.end();
+    }
+  });
+  clientSocket.on("close", function onClientClose() {
+    cleanup();
+  });
+
+  void (async function bootstrapUpstream(): Promise<void> {
+    let upstreamPort: number;
+    try {
+      upstreamPort = await withTimeout(
+        entry.ensureRunning(),
+        GATEWAY_START_TIMEOUT_MS,
+        "Gateway timed out while starting postgres runtime",
+      );
+    } catch {
+      closeBoth();
+      return;
+    }
+
+    try {
+      upstreamSocket = await waitForUpstreamConnection(upstreamPort);
+    } catch {
+      closeBoth();
+      return;
+    }
+
+    if (clientSocket.destroyed || !upstreamSocket) {
+      closeBoth();
+      return;
+    }
+
+    entry.sockets.add(upstreamSocket);
+
+    upstreamSocket.on("data", function onUpstreamData(chunk: Buffer) {
+      entry.onActivity();
+      if (!clientSocket.write(chunk)) {
+        upstreamSocket?.pause();
+      }
+    });
+
+    upstreamSocket.on("drain", function onUpstreamDrain() {
+      clientSocket.resume();
+    });
+
+    clientSocket.on("drain", function onClientDrain() {
+      upstreamSocket?.resume();
+    });
+
+    upstreamSocket.on("error", function onUpstreamError() {
+      closeBoth();
+    });
+    upstreamSocket.on("end", function onUpstreamEnd() {
+      clientSocket.end();
+    });
+    upstreamSocket.on("close", function onUpstreamClose() {
+      if (upstreamSocket) {
+        entry.sockets.delete(upstreamSocket);
+      }
+    });
+
+    for (const chunk of bufferedChunks) {
+      if (!upstreamSocket.write(chunk)) {
+        break;
+      }
+    }
+  })();
+}
+
+function closeServer(server: Server): Promise<void> {
+  return new Promise(function closeServerPromise(resolve) {
+    server.close(function onClose() {
+      resolve();
+    });
+  });
+}
+
+export async function startDatabaseTargetGateway(
+  config: DatabaseTargetGatewayConfig,
+): Promise<void> {
+  const existing = gatewayEntries.get(config.targetId);
+
+  if (existing && existing.listenPort === config.listenPort) {
+    existing.ensureRunning = config.ensureRunning;
+    existing.onActivity = config.onActivity;
+    return;
+  }
+
+  if (existing) {
+    await stopDatabaseTargetGateway(config.targetId);
+  }
+
+  const server = createServer(function onConnection(clientSocket) {
+    const entry = gatewayEntries.get(config.targetId);
+    if (!entry) {
+      clientSocket.destroy();
+      return;
+    }
+    handleGatewayConnection(entry, clientSocket);
+  });
+
+  await new Promise<void>(function startServer(resolve, reject) {
+    server.once("error", reject);
+    server.listen(config.listenPort, "0.0.0.0", function onListen() {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+
+  gatewayEntries.set(config.targetId, {
+    targetId: config.targetId,
+    listenPort: config.listenPort,
+    ensureRunning: config.ensureRunning,
+    onActivity: config.onActivity,
+    server,
+    sockets: new Set(),
+    activeConnections: 0,
+  });
+}
+
+export async function stopDatabaseTargetGateway(
+  targetId: string,
+): Promise<void> {
+  const entry = gatewayEntries.get(targetId);
+  if (!entry) {
+    return;
+  }
+
+  for (const socket of entry.sockets) {
+    if (!socket.destroyed) {
+      socket.destroy();
+    }
+  }
+
+  entry.sockets.clear();
+  entry.activeConnections = 0;
+  gatewayEntries.delete(targetId);
+
+  if (!entry.server.listening) {
+    return;
+  }
+
+  await closeServer(entry.server);
+}
+
+export async function stopAllDatabaseTargetGateways(): Promise<void> {
+  const targetIds = Array.from(gatewayEntries.keys());
+  for (const targetId of targetIds) {
+    await stopDatabaseTargetGateway(targetId);
+  }
+}
+
+export function isDatabaseTargetGatewayRunning(targetId: string): boolean {
+  return gatewayEntries.has(targetId);
+}
+
+export function getDatabaseTargetGatewayActiveConnections(
+  targetId: string,
+): number {
+  const entry = gatewayEntries.get(targetId);
+  return entry?.activeConnections ?? 0;
+}
+
+export function listDatabaseTargetGateways(): string[] {
+  return Array.from(gatewayEntries.keys());
+}

--- a/apps/app/src/lib/database-target-policy-scheduler.test.ts
+++ b/apps/app/src/lib/database-target-policy-scheduler.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isDatabaseTargetIdleDue,
+  isDatabaseTargetTtlExpired,
+} from "./database-target-policy-scheduler";
+
+describe("isDatabaseTargetTtlExpired", function describeTtl() {
+  test("returns false before ttl deadline", function testBeforeDeadline() {
+    const createdAt = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const now = createdAt + 2 * 60 * 60 * 1000;
+
+    const expired = isDatabaseTargetTtlExpired({
+      createdAt,
+      ttlValue: 3,
+      ttlUnit: "hours",
+      now,
+    });
+
+    expect(expired).toBe(false);
+  });
+
+  test("returns true after ttl deadline", function testAfterDeadline() {
+    const createdAt = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const now = createdAt + 2 * 24 * 60 * 60 * 1000;
+
+    const expired = isDatabaseTargetTtlExpired({
+      createdAt,
+      ttlValue: 1,
+      ttlUnit: "days",
+      now,
+    });
+
+    expect(expired).toBe(true);
+  });
+});
+
+describe("isDatabaseTargetIdleDue", function describeIdle() {
+  test("uses last activity timestamp", function testUsesLastActivity() {
+    const createdAt = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const lastActivityAt = createdAt + 5 * 60 * 1000;
+    const now = createdAt + 12 * 60 * 1000;
+
+    const due = isDatabaseTargetIdleDue({
+      createdAt,
+      lastActivityAt,
+      scaleToZeroMinutes: 10,
+      now,
+    });
+
+    expect(due).toBe(false);
+  });
+
+  test("falls back to createdAt when no activity", function testCreatedAtFallback() {
+    const createdAt = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const now = createdAt + 11 * 60 * 1000;
+
+    const due = isDatabaseTargetIdleDue({
+      createdAt,
+      lastActivityAt: null,
+      scaleToZeroMinutes: 10,
+      now,
+    });
+
+    expect(due).toBe(true);
+  });
+});

--- a/apps/app/src/lib/database-target-policy-scheduler.ts
+++ b/apps/app/src/lib/database-target-policy-scheduler.ts
@@ -1,0 +1,189 @@
+import { deleteDatabaseTarget, stopDatabaseTarget } from "./database-runtime";
+import { getDatabaseTargetGatewayActiveConnections } from "./database-target-gateway";
+import { db } from "./db";
+
+const CHECK_INTERVAL_MS = 60_000;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+
+export function isDatabaseTargetTtlExpired(input: {
+  createdAt: number;
+  ttlValue: number;
+  ttlUnit: "hours" | "days";
+  now?: number;
+}): boolean {
+  const now = input.now ?? Date.now();
+  const multiplier =
+    input.ttlUnit === "hours" ? 60 * 60 * 1000 : 24 * 60 * 60 * 1000;
+  return now - input.createdAt >= input.ttlValue * multiplier;
+}
+
+export function isDatabaseTargetIdleDue(input: {
+  lastActivityAt: number | null;
+  createdAt: number;
+  scaleToZeroMinutes: number;
+  now?: number;
+}): boolean {
+  const now = input.now ?? Date.now();
+  const lastActivityAt = input.lastActivityAt ?? input.createdAt;
+  return now - lastActivityAt >= input.scaleToZeroMinutes * 60 * 1000;
+}
+
+async function runScaleToZeroPolicy(now: number): Promise<void> {
+  const targets = await db
+    .selectFrom("databaseTargets")
+    .innerJoin("databases", "databases.id", "databaseTargets.databaseId")
+    .select([
+      "databaseTargets.id",
+      "databaseTargets.databaseId",
+      "databaseTargets.createdAt",
+      "databaseTargets.lastActivityAt",
+      "databaseTargets.scaleToZeroMinutes",
+    ])
+    .where("databaseTargets.kind", "=", "branch")
+    .where("databaseTargets.name", "!=", "main")
+    .where("databaseTargets.lifecycleStatus", "=", "active")
+    .where("databaseTargets.scaleToZeroMinutes", "is not", null)
+    .where("databases.engine", "=", "postgres")
+    .execute();
+
+  for (const target of targets) {
+    if (target.scaleToZeroMinutes === null) {
+      continue;
+    }
+
+    if (getDatabaseTargetGatewayActiveConnections(target.id) > 0) {
+      continue;
+    }
+
+    if (
+      !isDatabaseTargetIdleDue({
+        lastActivityAt: target.lastActivityAt,
+        createdAt: target.createdAt,
+        scaleToZeroMinutes: target.scaleToZeroMinutes,
+        now,
+      })
+    ) {
+      continue;
+    }
+
+    try {
+      await stopDatabaseTarget({
+        databaseId: target.databaseId,
+        targetId: target.id,
+      });
+    } catch (error) {
+      console.error(
+        "[database-target-policy-scheduler] Failed to auto-stop target",
+        {
+          targetId: target.id,
+          error,
+        },
+      );
+    }
+  }
+}
+
+async function runTtlPolicy(now: number): Promise<void> {
+  const targets = await db
+    .selectFrom("databaseTargets")
+    .innerJoin("databases", "databases.id", "databaseTargets.databaseId")
+    .select([
+      "databaseTargets.id",
+      "databaseTargets.databaseId",
+      "databaseTargets.name",
+      "databaseTargets.createdAt",
+      "databaseTargets.ttlValue",
+      "databaseTargets.ttlUnit",
+    ])
+    .where("databaseTargets.kind", "=", "branch")
+    .where("databaseTargets.name", "!=", "main")
+    .where("databaseTargets.ttlValue", "is not", null)
+    .where("databaseTargets.ttlUnit", "is not", null)
+    .where("databases.engine", "=", "postgres")
+    .execute();
+
+  for (const target of targets) {
+    if (target.ttlValue === null || target.ttlUnit === null) {
+      continue;
+    }
+
+    if (
+      !isDatabaseTargetTtlExpired({
+        createdAt: target.createdAt,
+        ttlValue: target.ttlValue,
+        ttlUnit: target.ttlUnit,
+        now,
+      })
+    ) {
+      continue;
+    }
+
+    if (getDatabaseTargetGatewayActiveConnections(target.id) > 0) {
+      continue;
+    }
+
+    const attachment = await db
+      .selectFrom("environmentDatabaseAttachments")
+      .select("id")
+      .where("targetId", "=", target.id)
+      .executeTakeFirst();
+
+    if (attachment) {
+      console.log(
+        "[database-target-policy-scheduler] TTL delete skipped for attached target",
+        {
+          targetId: target.id,
+        },
+      );
+      continue;
+    }
+
+    try {
+      await deleteDatabaseTarget({
+        databaseId: target.databaseId,
+        targetId: target.id,
+      });
+    } catch (error) {
+      console.error(
+        "[database-target-policy-scheduler] Failed to auto-delete target",
+        {
+          targetId: target.id,
+          error,
+        },
+      );
+    }
+  }
+}
+
+export async function runDatabaseTargetPolicyScheduler(): Promise<void> {
+  const now = Date.now();
+  await runScaleToZeroPolicy(now);
+  await runTtlPolicy(now);
+}
+
+function checkAndRun(): void {
+  runDatabaseTargetPolicyScheduler().catch(function onError(error) {
+    console.error("[database-target-policy-scheduler] Error:", error);
+  });
+}
+
+export function startDatabaseTargetPolicyScheduler(): void {
+  if (intervalId) {
+    return;
+  }
+
+  intervalId = setInterval(checkAndRun, CHECK_INTERVAL_MS);
+  checkAndRun();
+  console.log("[database-target-policy-scheduler] Started");
+}
+
+export function stopDatabaseTargetPolicyScheduler(): void {
+  if (!intervalId) {
+    return;
+  }
+
+  clearInterval(intervalId);
+  intervalId = null;
+  console.log("[database-target-policy-scheduler] Stopped");
+}

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -599,6 +599,11 @@ export const databaseTargetsSchema = z.object({
   runtimeServiceId: z.string(),
   lifecycleStatus: z.enum(["active", "stopped", "expired"]),
   providerRefJson: z.string(),
+  ttlValue: z.number().nullable(),
+  ttlUnit: z.enum(["hours", "days"]).nullable(),
+  scaleToZeroMinutes: z.number().nullable(),
+  lastActivityAt: z.number().nullable(),
+  runtimeHostPort: z.number().nullable(),
   createdAt: z.number(),
 });
 
@@ -612,6 +617,11 @@ export const newDatabaseTargetsSchema = z.object({
   runtimeServiceId: z.string(),
   lifecycleStatus: z.enum(["active", "stopped", "expired"]).optional(),
   providerRefJson: z.string().optional(),
+  ttlValue: z.number().nullable(),
+  ttlUnit: z.enum(["hours", "days"]).nullable(),
+  scaleToZeroMinutes: z.number().nullable(),
+  lastActivityAt: z.number().nullable(),
+  runtimeHostPort: z.number().nullable(),
   createdAt: z.number(),
 });
 
@@ -625,6 +635,11 @@ export const databaseTargetsUpdateSchema = z.object({
   runtimeServiceId: z.string().optional(),
   lifecycleStatus: z.enum(["active", "stopped", "expired"]).optional(),
   providerRefJson: z.string().optional(),
+  ttlValue: z.number().nullable().optional(),
+  ttlUnit: z.enum(["hours", "days"]).nullable().optional(),
+  scaleToZeroMinutes: z.number().nullable().optional(),
+  lastActivityAt: z.number().nullable().optional(),
+  runtimeHostPort: z.number().nullable().optional(),
   createdAt: z.number().optional(),
 });
 

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -80,6 +80,11 @@ export interface DatabaseTargets {
   createdAt: number;
   runtimeServiceId: Generated<string>;
   hostname: Generated<string>;
+  ttlValue: number | null;
+  ttlUnit: 'hours' | 'days' | null;
+  scaleToZeroMinutes: number | null;
+  lastActivityAt: number | null;
+  runtimeHostPort: number | null;
 }
 
 export interface Databases {

--- a/apps/app/src/server/databases.ts
+++ b/apps/app/src/server/databases.ts
@@ -109,6 +109,59 @@ async function assertPostgresBranch(databaseId: string, targetId: string) {
   return target;
 }
 
+async function assertBranchPolicyPatchAllowed(input: {
+  databaseId: string;
+  targetId: string;
+  ttlValue?: number | null;
+  ttlUnit?: "hours" | "days" | null;
+  scaleToZeroMinutes?: number | null;
+}) {
+  const hasTtlValue = input.ttlValue !== undefined;
+  const hasTtlUnit = input.ttlUnit !== undefined;
+  const touchesPolicyFields =
+    hasTtlValue || hasTtlUnit || input.scaleToZeroMinutes !== undefined;
+
+  if (!touchesPolicyFields) {
+    return;
+  }
+
+  if (hasTtlValue !== hasTtlUnit) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "ttlValue and ttlUnit must be set together",
+    });
+  }
+
+  const database = await getDatabase(input.databaseId);
+  const target = await getTargetByDatabase(input.databaseId, input.targetId);
+
+  if (database.engine !== "postgres" || target.kind !== "branch") {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "TTL and scale to zero are only available for postgres branches",
+    });
+  }
+
+  const enablesTtl = input.ttlValue !== null || input.ttlUnit !== null;
+  const enablesScaleToZero = input.scaleToZeroMinutes !== null;
+  if (target.name === "main" && (enablesTtl || enablesScaleToZero)) {
+    throw new ORPCError("BAD_REQUEST", {
+      message: "main cannot use TTL or scale to zero",
+    });
+  }
+
+  if (enablesScaleToZero) {
+    const attachment = await db
+      .selectFrom("environmentDatabaseAttachments")
+      .select("id")
+      .where("targetId", "=", target.id)
+      .executeTakeFirst();
+    if (attachment) {
+      throw new ORPCError("BAD_REQUEST", {
+        message: "Scale to zero only works for detached branches right now",
+      });
+    }
+  }
+}
+
 export const databases = {
   create: os.databases.create.handler(async ({ input }) => {
     const project = await db
@@ -289,11 +342,21 @@ export const databases = {
     async ({ input }) => {
       try {
         await getTargetByDatabase(input.databaseId, input.targetId);
+        await assertBranchPolicyPatchAllowed({
+          databaseId: input.databaseId,
+          targetId: input.targetId,
+          ttlValue: input.ttlValue,
+          ttlUnit: input.ttlUnit,
+          scaleToZeroMinutes: input.scaleToZeroMinutes,
+        });
         return await patchDatabaseTargetRuntimeSettings({
           targetId: input.targetId,
           name: input.name,
           hostname: input.hostname,
           lifecycleStatus: input.lifecycleStatus,
+          ttlValue: input.ttlValue,
+          ttlUnit: input.ttlUnit,
+          scaleToZeroMinutes: input.scaleToZeroMinutes,
           memoryLimit: input.memoryLimit,
           cpuLimit: input.cpuLimit,
         });
@@ -366,11 +429,21 @@ export const databases = {
   patchBranch: os.databases.patchBranch.handler(async ({ input }) => {
     try {
       await assertPostgresBranch(input.databaseId, input.targetId);
+      await assertBranchPolicyPatchAllowed({
+        databaseId: input.databaseId,
+        targetId: input.targetId,
+        ttlValue: input.ttlValue,
+        ttlUnit: input.ttlUnit,
+        scaleToZeroMinutes: input.scaleToZeroMinutes,
+      });
       return await patchDatabaseTargetRuntimeSettings({
         targetId: input.targetId,
         name: input.name,
         hostname: input.hostname,
         lifecycleStatus: input.lifecycleStatus,
+        ttlValue: input.ttlValue,
+        ttlUnit: input.ttlUnit,
+        scaleToZeroMinutes: input.scaleToZeroMinutes,
         memoryLimit: input.memoryLimit,
         cpuLimit: input.cpuLimit,
       });


### PR DESCRIPTION
## Summary
- add branch TTL settings (`hours`/`days`) for postgres branches
- add scale-to-zero for detached postgres branches with stable client host/port
- add in-process TCP gateway that auto-wakes branch on incoming connection and buffers first bytes
- add policy scheduler for idle auto-stop and TTL auto-delete (skip attached branches)
- restore gateways and start scheduler on app startup
- extend API contracts/server validation and branch settings UI
- extend e2e group-07 for idle stop -> wake and TTL auto-delete path

## Behavior
- no wake API endpoint
- wake is triggered by first incoming TCP connection
- client connection string shape/host/port/protocol stay unchanged
- startup wait cap is 60s

## Validation
- bun run lint
- bun run typecheck
- bun --cwd apps/app test ./src/lib/database-target-policy-scheduler.test.ts ./src/lib/database-target-gateway.test.ts
- bash -n apps/app/scripts/e2e/group-07-database.sh
