### PR TITLE
refactor(db): remove binding flow and split database settings

### DIFF
--- a/apps/app/scripts/e2e/group-07-database.sh
+++ b/apps/app/scripts/e2e/group-07-database.sh
@@ -65,12 +65,6 @@ TARGET_FOUND=$(json_get "$TARGETS" '.[] | select(.id == "'"$TARGET_ID"'") | .id'
 [ "$TARGET_FOUND" != "$TARGET_ID" ] && fail "Target not found: $TARGETS"
 log "Main target exists"
 
-log "Verifying environment attachment..."
-ATTACHMENTS=$(api "$BASE_URL/api/environments/$ENV_ID/database-attachments")
-ATTACHED_TARGET_ID=$(json_get "$ATTACHMENTS" '.[] | select(.databaseId == "'"$DB_ID"'") | .targetId')
-[ "$ATTACHED_TARGET_ID" != "$TARGET_ID" ] && fail "Expected target attachment $TARGET_ID, got: $ATTACHED_TARGET_ID"
-log "Environment attached to main target"
-
 PROVIDER_REF_JSON=$(json_get "$DB_CREATE" '.target.providerRefJson')
 POSTGRES_USER=$(provider_ref_field "$PROVIDER_REF_JSON" "username")
 POSTGRES_PASSWORD=$(provider_ref_field "$PROVIDER_REF_JSON" "password")

--- a/apps/app/src/app/(workspace)/_components/create-service-modal-provider.tsx
+++ b/apps/app/src/app/(workspace)/_components/create-service-modal-provider.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+interface CreateServiceModalContextValue {
+  openCreateServiceModal: () => void;
+}
+
+const CreateServiceModalContext =
+  createContext<CreateServiceModalContextValue | null>(null);
+
+export function CreateServiceModalProvider({
+  children,
+  value,
+}: {
+  children: React.ReactNode;
+  value: CreateServiceModalContextValue;
+}): React.ReactElement {
+  return (
+    <CreateServiceModalContext.Provider value={value}>
+      {children}
+    </CreateServiceModalContext.Provider>
+  );
+}
+
+export function useCreateServiceModal(): CreateServiceModalContextValue {
+  const context = useContext(CreateServiceModalContext);
+  if (!context) {
+    throw new Error(
+      "useCreateServiceModal must be used within CreateServiceModalProvider",
+    );
+  }
+  return context;
+}

--- a/apps/app/src/app/(workspace)/layout.tsx
+++ b/apps/app/src/app/(workspace)/layout.tsx
@@ -2,11 +2,12 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { useParams, usePathname, useRouter } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { MainContentHeader } from "@/components/main-content-header";
 import { Skeleton } from "@/components/ui/skeleton";
 import { orpc } from "@/lib/orpc-client";
 import { cn } from "@/lib/utils";
+import { CreateServiceModalProvider } from "./_components/create-service-modal-provider";
 import { WorkspaceLeftMenu } from "./_components/workspace-left-menu";
 import { CreateServiceModal } from "./projects/[id]/_components/create-service-modal";
 import { ProjectLeftMenu } from "./projects/[id]/_components/project-left-menu";
@@ -50,7 +51,6 @@ export default function WorkspaceLayout({
 
   const [createServiceModalOpen, setCreateServiceModalOpen] = useState(false);
   const [createEnvDialogOpen, setCreateEnvDialogOpen] = useState(false);
-  const [createQueryValue, setCreateQueryValue] = useState<string | null>(null);
 
   const { data: environments = [], isLoading: isEnvironmentsLoading } =
     useQuery({
@@ -74,7 +74,7 @@ export default function WorkspaceLayout({
       const production = environments.find(
         (environment) => environment.type === "production",
       );
-      return production?.id ?? "";
+      return production?.id ?? environments[0]?.id ?? "";
     },
     [isProjectPage, params.envId, environments],
   );
@@ -164,56 +164,24 @@ export default function WorkspaceLayout({
       ? "overflow-hidden bg-neutral-950/20"
       : "overflow-auto p-6",
   );
-  const shouldOpenCreateService = createQueryValue === "service";
-
-  useEffect(
-    function syncCreateQueryValue() {
-      if (typeof window === "undefined") {
-        return;
-      }
-      const currentPathname = window.location.pathname;
-      if (currentPathname !== pathname) {
-        return;
-      }
-      const currentSearchParams = new URLSearchParams(window.location.search);
-      setCreateQueryValue(currentSearchParams.get("create"));
-    },
-    [pathname],
-  );
-
-  useEffect(
-    function syncCreateServiceFromQuery() {
-      if (!isProjectPage || !currentEnvId || !shouldOpenCreateService) {
-        return;
-      }
-      setCreateServiceModalOpen(true);
-    },
-    [currentEnvId, isProjectPage, shouldOpenCreateService],
-  );
-
-  function clearCreateQueryParam() {
-    if (typeof window === "undefined") {
-      return;
-    }
-    const nextParams = new URLSearchParams(window.location.search);
-    if (!nextParams.has("create")) {
-      return;
-    }
-    nextParams.delete("create");
-    const nextQuery = nextParams.toString();
-    setCreateQueryValue(nextParams.get("create"));
-    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname);
-  }
 
   function handleCreateServiceModalOpenChange(open: boolean) {
     setCreateServiceModalOpen(open);
-    if (!open) {
-      clearCreateQueryParam();
-    }
   }
 
+  const createServiceModalContextValue = useMemo(
+    function getCreateServiceModalContextValue() {
+      return {
+        openCreateServiceModal: function openCreateServiceModal() {
+          setCreateServiceModalOpen(true);
+        },
+      };
+    },
+    [],
+  );
+
   return (
-    <>
+    <CreateServiceModalProvider value={createServiceModalContextValue}>
       <main className="fixed inset-0 flex min-h-0">
         {isProjectPage ? (
           isEnvironmentsLoading ? (
@@ -225,7 +193,7 @@ export default function WorkspaceLayout({
               selectedServiceId={selectedServiceId}
               selectedDatabaseId={selectedDatabaseId}
               onOpenCreateService={function openCreateService() {
-                setCreateServiceModalOpen(true);
+                createServiceModalContextValue.openCreateServiceModal();
               }}
               onOpenCreateEnvironment={function openCreateEnvironment() {
                 setCreateEnvDialogOpen(true);
@@ -280,6 +248,6 @@ export default function WorkspaceLayout({
           onOpenChange={setCreateEnvDialogOpen}
         />
       )}
-    </>
+    </CreateServiceModalProvider>
   );
 }

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/create-service-modal.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/create-service-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import type { LucideIcon } from "lucide-react";
 import {
   ChevronLeft,
@@ -42,7 +42,6 @@ import {
   getDatabaseLogoAlt,
   getDatabaseLogoUrl,
 } from "@/lib/database-logo";
-import { orpc } from "@/lib/orpc-client";
 import { RepoSelector } from "../services/new/_components/repo-selector";
 import { type StagedService, StagedServicesList } from "./staged-services-list";
 
@@ -131,7 +130,6 @@ export function CreateServiceModal({
   onServiceCreated,
   onDatabaseCreated,
 }: CreateServiceModalProps): React.ReactElement {
-  const queryClient = useQueryClient();
   const createMutation = useCreateService(environmentId);
   const createDatabaseMutation = useCreateDatabase(projectId);
   const scanMutation = useScanRepo();
@@ -387,22 +385,6 @@ export function CreateServiceModal({
       const result = await createDatabaseMutation.mutateAsync({
         name: nextName,
         engine: databaseEngine,
-      });
-      await orpc.databases.putAttachment.call({
-        envId: environmentId,
-        databaseId: result.database.id,
-        targetId: result.target.id,
-        mode: "managed",
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listEnvironmentAttachments.key({
-          input: { envId: environmentId },
-        }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.environments.get.key({
-          input: { envId: environmentId },
-        }),
       });
       toast.success("Database created");
       resetState();

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-backup-settings-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-backup-settings-panel.tsx
@@ -40,6 +40,7 @@ export interface DatabaseBackupTargetOption {
 interface DatabaseBackupSettingsPanelProps {
   databaseId: string;
   targets: DatabaseBackupTargetOption[];
+  mode?: "all" | "backup" | "restore";
 }
 
 interface BackupFormState {
@@ -213,6 +214,7 @@ function resolveProviderFields(form: BackupFormState): {
 export function DatabaseBackupSettingsPanel({
   databaseId,
   targets,
+  mode = "all",
 }: DatabaseBackupSettingsPanelProps) {
   const backupConfigQuery = useDatabaseBackupConfig(databaseId);
   const listBackupsQuery = useListDatabaseBackups(databaseId);
@@ -463,512 +465,523 @@ export function DatabaseBackupSettingsPanel({
       }),
     ),
   );
+  const showBackupSection = mode === "all" || mode === "backup";
+  const showRestoreSection = mode === "all" || mode === "restore";
 
   return (
     <div className="space-y-4">
-      <SettingCard
-        title="Backups"
-        description="Configure branch backups to an S3-compatible bucket."
-        footerRight={
-          <div className="flex items-center gap-2">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={function onClick() {
-                void testConnection();
-              }}
-              disabled={
-                upsertMutation.isPending || testConnectionMutation.isPending
-              }
-            >
-              {testConnectionMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                  Testing...
-                </>
-              ) : (
-                "Test connection"
-              )}
-            </Button>
-            <Button
-              type="button"
-              variant="outline"
-              onClick={function onClick() {
-                void runBackupNow();
-              }}
-              disabled={runBackupMutation.isPending}
-            >
-              {runBackupMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                  Running...
-                </>
-              ) : (
-                "Run backup now"
-              )}
-            </Button>
-            <Button
-              type="button"
-              onClick={function onClick() {
-                void saveConfig();
-              }}
-              disabled={upsertMutation.isPending}
-            >
-              {upsertMutation.isPending ? (
-                <>
-                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                  Saving...
-                </>
-              ) : (
-                "Save"
-              )}
-            </Button>
-          </div>
-        }
-      >
-        <div className="space-y-4">
-          <div className="flex items-center gap-3">
-            <Switch
-              checked={form.enabled}
-              onCheckedChange={function onCheckedChange(value) {
-                setForm(function update(current) {
-                  return { ...current, enabled: value };
-                });
-              }}
-            />
-            <Label>Enable backups</Label>
-            {backupConfigQuery.data?.running && (
-              <Badge
+      {showBackupSection && (
+        <SettingCard
+          title="Backups"
+          description="Configure branch backups to an S3-compatible bucket."
+          footerRight={
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
                 variant="outline"
-                className="border-neutral-700 text-neutral-300"
-              >
-                running
-              </Badge>
-            )}
-          </div>
-
-          <div className="space-y-2">
-            <Label>Branches to backup</Label>
-            {mainTarget && (
-              <label className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200">
-                <input
-                  type="checkbox"
-                  checked={form.selectedTargetIds.includes(mainTarget.id)}
-                  onChange={function onChange() {
-                    toggleTarget(mainTarget.id);
-                  }}
-                />
-                <span>{mainTarget.name}</span>
-              </label>
-            )}
-            {otherBranchRows.length > 0 && (
-              <div className="space-y-2">
-                <button
-                  type="button"
-                  className="flex w-full items-center justify-between rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200"
-                  onClick={function onClick() {
-                    setShowOtherBranches(function update(current) {
-                      return !current;
-                    });
-                  }}
-                >
-                  <span>
-                    Branches ({otherBranchRows.length})
-                    {selectedOtherBranches > 0 &&
-                      ` • ${selectedOtherBranches} selected`}
-                  </span>
-                  <ChevronRight
-                    className={
-                      showOtherBranches
-                        ? "h-4 w-4 rotate-90 transition-transform"
-                        : "h-4 w-4 transition-transform"
-                    }
-                  />
-                </button>
-                {showOtherBranches && (
-                  <div className="space-y-2">
-                    {otherBranchRows.map(function renderRow(row) {
-                      const target = row.target;
-                      const checked = form.selectedTargetIds.includes(
-                        target.id,
-                      );
-                      return (
-                        <label
-                          key={target.id}
-                          className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200"
-                          style={{ paddingLeft: `${12 + row.depth * 20}px` }}
-                        >
-                          <input
-                            type="checkbox"
-                            checked={checked}
-                            onChange={function onChange() {
-                              toggleTarget(target.id);
-                            }}
-                          />
-                          <span>{target.name}</span>
-                        </label>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-            )}
-            {!mainTarget && (
-              <div className="text-xs text-neutral-400">
-                No branches available.
-              </div>
-            )}
-          </div>
-
-          <div className="grid gap-3 md:grid-cols-3">
-            <div className="space-y-2">
-              <Label>Every</Label>
-              <Input
-                type="number"
-                min={1}
-                value={form.intervalValue}
-                onChange={function onChange(event) {
-                  setForm(function update(current) {
-                    return {
-                      ...current,
-                      intervalValue:
-                        Number.parseInt(event.target.value, 10) || 1,
-                    };
-                  });
+                onClick={function onClick() {
+                  void testConnection();
                 }}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Unit</Label>
-              <Select
-                value={form.intervalUnit}
-                onValueChange={function onChange(value) {
-                  setForm(function update(current) {
-                    return {
-                      ...current,
-                      intervalUnit: value as BackupIntervalUnit,
-                    };
-                  });
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="minutes">minutes</SelectItem>
-                  <SelectItem value="hours">hours</SelectItem>
-                  <SelectItem value="days">days</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label>Retention days</Label>
-              <Input
-                type="number"
-                min={1}
-                value={form.retentionDays}
-                onChange={function onChange(event) {
-                  setForm(function update(current) {
-                    return {
-                      ...current,
-                      retentionDays:
-                        Number.parseInt(event.target.value, 10) || 1,
-                    };
-                  });
-                }}
-              />
-            </div>
-          </div>
-
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Provider</Label>
-              <Select
-                value={form.s3Provider}
-                onValueChange={function onChange(value) {
-                  setForm(function update(current) {
-                    return { ...current, s3Provider: value as BackupProvider };
-                  });
-                }}
-              >
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="aws">AWS S3</SelectItem>
-                  <SelectItem value="cloudflare">Cloudflare R2</SelectItem>
-                  <SelectItem value="backblaze">Backblaze B2</SelectItem>
-                  <SelectItem value="custom">Custom S3</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-2">
-              <Label>Bucket</Label>
-              <Input
-                value={form.bucket}
-                onChange={function onChange(event) {
-                  setForm(function update(current) {
-                    return { ...current, bucket: event.target.value };
-                  });
-                }}
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>Access key id</Label>
-              <Input
-                value={form.accessKeyId}
-                onChange={function onChange(event) {
-                  setForm(function update(current) {
-                    return { ...current, accessKeyId: event.target.value };
-                  });
-                }}
-              />
-            </div>
-            <div className="space-y-2 md:col-span-2">
-              <Label>Secret access key</Label>
-              <Input
-                type="password"
-                value={form.secretAccessKey}
-                onChange={function onChange(event) {
-                  setForm(function update(current) {
-                    return {
-                      ...current,
-                      secretAccessKey: event.target.value,
-                    };
-                  });
-                }}
-                placeholder={
-                  form.useExistingSecret
-                    ? "leave empty to keep existing key"
-                    : "required"
+                disabled={
+                  upsertMutation.isPending || testConnectionMutation.isPending
                 }
-              />
-            </div>
-          </div>
-
-          {form.s3Provider === "cloudflare" && (
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Account id</Label>
-                <Input
-                  value={form.accountId}
-                  onChange={function onChange(event) {
-                    setForm(function update(current) {
-                      return { ...current, accountId: event.target.value };
-                    });
-                  }}
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>Endpoint</Label>
-                <Input
-                  value={
-                    form.accountId.trim().length > 0
-                      ? `https://${form.accountId.trim()}.r2.cloudflarestorage.com`
-                      : ""
-                  }
-                  readOnly
-                />
-              </div>
-            </div>
-          )}
-
-          {form.s3Provider === "backblaze" && (
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Region</Label>
-                <Input
-                  value={form.region}
-                  onChange={function onChange(event) {
-                    setForm(function update(current) {
-                      return { ...current, region: event.target.value };
-                    });
-                  }}
-                  placeholder="us-west-004"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>Endpoint</Label>
-                <Input
-                  value={
-                    form.region.trim().length > 0
-                      ? `https://s3.${form.region.trim()}.backblazeb2.com`
-                      : ""
-                  }
-                  readOnly
-                />
-              </div>
-            </div>
-          )}
-
-          {(form.s3Provider === "aws" || form.s3Provider === "custom") && (
-            <div className="grid gap-3 md:grid-cols-2">
-              <div className="space-y-2">
-                <Label>Region</Label>
-                <Input
-                  value={form.region}
-                  onChange={function onChange(event) {
-                    setForm(function update(current) {
-                      return { ...current, region: event.target.value };
-                    });
-                  }}
-                  placeholder="us-east-1"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>
-                  Endpoint {form.s3Provider === "custom" ? "" : "(optional)"}
-                </Label>
-                <Input
-                  value={form.endpoint}
-                  onChange={function onChange(event) {
-                    setForm(function update(current) {
-                      return { ...current, endpoint: event.target.value };
-                    });
-                  }}
-                  placeholder={
-                    form.s3Provider === "custom"
-                      ? "https://s3.example.com"
-                      : "https://s3.us-east-1.amazonaws.com"
-                  }
-                />
-              </div>
-            </div>
-          )}
-
-          <div className="space-y-1 text-xs text-neutral-400">
-            <div>
-              Last run:{" "}
-              {backupConfigQuery.data?.lastRunAt
-                ? formatDate(backupConfigQuery.data.lastRunAt)
-                : "never"}
-            </div>
-            <div>
-              Last success:{" "}
-              {backupConfigQuery.data?.lastSuccessAt
-                ? formatDate(backupConfigQuery.data.lastSuccessAt)
-                : "never"}
-            </div>
-            {backupConfigQuery.data?.lastError && (
-              <div className="text-red-300">
-                Last error: {backupConfigQuery.data.lastError}
-              </div>
-            )}
-          </div>
-        </div>
-      </SettingCard>
-
-      <SettingCard
-        title="Restore"
-        description="Restore one backup to one branch."
-      >
-        <div className="space-y-3">
-          {listBackupsQuery.isLoading && (
-            <div className="text-sm text-neutral-400">Loading backups...</div>
-          )}
-
-          {listBackupsQuery.data && listBackupsQuery.data.length === 0 && (
-            <div className="text-sm text-neutral-400">No backups found.</div>
-          )}
-
-          <div className="grid gap-3 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>Backup</Label>
-              <Select
-                value={restoreBackupPath || undefined}
-                onValueChange={function onValueChange(value) {
-                  const backup = listBackupsQuery.data?.find(
-                    function byPath(item) {
-                      return item.backupPath === value;
-                    },
-                  );
-                  if (backup) {
-                    startRestore(backup.backupPath, backup.sourceTargetName);
-                    return;
-                  }
-                  setRestoreBackupPath(value);
-                }}
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select backup" />
-                </SelectTrigger>
-                <SelectContent>
-                  {listBackupsQuery.data?.map(function renderBackup(backup) {
-                    return (
-                      <SelectItem
-                        key={backup.backupPath}
-                        value={backup.backupPath}
-                      >
-                        {formatBackupLabel(backup)}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
-              {selectedBackup && (
-                <div className="text-xs text-neutral-500">
-                  {selectedBackup.backupPath}
+                {testConnectionMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    Testing...
+                  </>
+                ) : (
+                  "Test connection"
+                )}
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={function onClick() {
+                  void runBackupNow();
+                }}
+                disabled={runBackupMutation.isPending}
+              >
+                {runBackupMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    Running...
+                  </>
+                ) : (
+                  "Run backup now"
+                )}
+              </Button>
+              <Button
+                type="button"
+                onClick={function onClick() {
+                  void saveConfig();
+                }}
+                disabled={upsertMutation.isPending}
+              >
+                {upsertMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                    Saving...
+                  </>
+                ) : (
+                  "Save"
+                )}
+              </Button>
+            </div>
+          }
+        >
+          <div className="space-y-4">
+            <div className="flex items-center gap-3">
+              <Switch
+                checked={form.enabled}
+                onCheckedChange={function onCheckedChange(value) {
+                  setForm(function update(current) {
+                    return { ...current, enabled: value };
+                  });
+                }}
+              />
+              <Label>Enable backups</Label>
+              {backupConfigQuery.data?.running && (
+                <Badge
+                  variant="outline"
+                  className="border-neutral-700 text-neutral-300"
+                >
+                  running
+                </Badge>
+              )}
+            </div>
+
+            <div className="space-y-2">
+              <Label>Branches to backup</Label>
+              {mainTarget && (
+                <label className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200">
+                  <input
+                    type="checkbox"
+                    checked={form.selectedTargetIds.includes(mainTarget.id)}
+                    onChange={function onChange() {
+                      toggleTarget(mainTarget.id);
+                    }}
+                  />
+                  <span>{mainTarget.name}</span>
+                </label>
+              )}
+              {otherBranchRows.length > 0 && (
+                <div className="space-y-2">
+                  <button
+                    type="button"
+                    className="flex w-full items-center justify-between rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200"
+                    onClick={function onClick() {
+                      setShowOtherBranches(function update(current) {
+                        return !current;
+                      });
+                    }}
+                  >
+                    <span>
+                      Branches ({otherBranchRows.length})
+                      {selectedOtherBranches > 0 &&
+                        ` • ${selectedOtherBranches} selected`}
+                    </span>
+                    <ChevronRight
+                      className={
+                        showOtherBranches
+                          ? "h-4 w-4 rotate-90 transition-transform"
+                          : "h-4 w-4 transition-transform"
+                      }
+                    />
+                  </button>
+                  {showOtherBranches && (
+                    <div className="space-y-2">
+                      {otherBranchRows.map(function renderRow(row) {
+                        const target = row.target;
+                        const checked = form.selectedTargetIds.includes(
+                          target.id,
+                        );
+                        return (
+                          <label
+                            key={target.id}
+                            className="flex items-center gap-2 rounded border border-neutral-700 px-3 py-2 text-sm text-neutral-200"
+                            style={{ paddingLeft: `${12 + row.depth * 20}px` }}
+                          >
+                            <input
+                              type="checkbox"
+                              checked={checked}
+                              onChange={function onChange() {
+                                toggleTarget(target.id);
+                              }}
+                            />
+                            <span>{target.name}</span>
+                          </label>
+                        );
+                      })}
+                    </div>
+                  )}
+                </div>
+              )}
+              {!mainTarget && (
+                <div className="text-xs text-neutral-400">
+                  No branches available.
                 </div>
               )}
             </div>
-            <div className="space-y-2">
-              <Label>Target branch</Label>
-              <Select
-                value={restoreTargetBranchName || undefined}
-                onValueChange={setRestoreTargetBranchName}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Select target branch" />
-                </SelectTrigger>
-                <SelectContent>
-                  {restoreBranchNames.map(function renderBranch(name) {
-                    return (
-                      <SelectItem key={name} value={name}>
-                        {name}
-                      </SelectItem>
-                    );
-                  })}
-                </SelectContent>
-              </Select>
+
+            <div className="grid gap-3 md:grid-cols-3">
+              <div className="space-y-2">
+                <Label>Every</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={form.intervalValue}
+                  onChange={function onChange(event) {
+                    setForm(function update(current) {
+                      return {
+                        ...current,
+                        intervalValue:
+                          Number.parseInt(event.target.value, 10) || 1,
+                      };
+                    });
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Unit</Label>
+                <Select
+                  value={form.intervalUnit}
+                  onValueChange={function onChange(value) {
+                    setForm(function update(current) {
+                      return {
+                        ...current,
+                        intervalUnit: value as BackupIntervalUnit,
+                      };
+                    });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="minutes">minutes</SelectItem>
+                    <SelectItem value="hours">hours</SelectItem>
+                    <SelectItem value="days">days</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Retention days</Label>
+                <Input
+                  type="number"
+                  min={1}
+                  value={form.retentionDays}
+                  onChange={function onChange(event) {
+                    setForm(function update(current) {
+                      return {
+                        ...current,
+                        retentionDays:
+                          Number.parseInt(event.target.value, 10) || 1,
+                      };
+                    });
+                  }}
+                />
+              </div>
+            </div>
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Provider</Label>
+                <Select
+                  value={form.s3Provider}
+                  onValueChange={function onChange(value) {
+                    setForm(function update(current) {
+                      return {
+                        ...current,
+                        s3Provider: value as BackupProvider,
+                      };
+                    });
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="aws">AWS S3</SelectItem>
+                    <SelectItem value="cloudflare">Cloudflare R2</SelectItem>
+                    <SelectItem value="backblaze">Backblaze B2</SelectItem>
+                    <SelectItem value="custom">Custom S3</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="space-y-2">
+                <Label>Bucket</Label>
+                <Input
+                  value={form.bucket}
+                  onChange={function onChange(event) {
+                    setForm(function update(current) {
+                      return { ...current, bucket: event.target.value };
+                    });
+                  }}
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Access key id</Label>
+                <Input
+                  value={form.accessKeyId}
+                  onChange={function onChange(event) {
+                    setForm(function update(current) {
+                      return { ...current, accessKeyId: event.target.value };
+                    });
+                  }}
+                />
+              </div>
+              <div className="space-y-2 md:col-span-2">
+                <Label>Secret access key</Label>
+                <Input
+                  type="password"
+                  value={form.secretAccessKey}
+                  onChange={function onChange(event) {
+                    setForm(function update(current) {
+                      return {
+                        ...current,
+                        secretAccessKey: event.target.value,
+                      };
+                    });
+                  }}
+                  placeholder={
+                    form.useExistingSecret
+                      ? "leave empty to keep existing key"
+                      : "required"
+                  }
+                />
+              </div>
+            </div>
+
+            {form.s3Provider === "cloudflare" && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Account id</Label>
+                  <Input
+                    value={form.accountId}
+                    onChange={function onChange(event) {
+                      setForm(function update(current) {
+                        return { ...current, accountId: event.target.value };
+                      });
+                    }}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Endpoint</Label>
+                  <Input
+                    value={
+                      form.accountId.trim().length > 0
+                        ? `https://${form.accountId.trim()}.r2.cloudflarestorage.com`
+                        : ""
+                    }
+                    readOnly
+                  />
+                </div>
+              </div>
+            )}
+
+            {form.s3Provider === "backblaze" && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Region</Label>
+                  <Input
+                    value={form.region}
+                    onChange={function onChange(event) {
+                      setForm(function update(current) {
+                        return { ...current, region: event.target.value };
+                      });
+                    }}
+                    placeholder="us-west-004"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>Endpoint</Label>
+                  <Input
+                    value={
+                      form.region.trim().length > 0
+                        ? `https://s3.${form.region.trim()}.backblazeb2.com`
+                        : ""
+                    }
+                    readOnly
+                  />
+                </div>
+              </div>
+            )}
+
+            {(form.s3Provider === "aws" || form.s3Provider === "custom") && (
+              <div className="grid gap-3 md:grid-cols-2">
+                <div className="space-y-2">
+                  <Label>Region</Label>
+                  <Input
+                    value={form.region}
+                    onChange={function onChange(event) {
+                      setForm(function update(current) {
+                        return { ...current, region: event.target.value };
+                      });
+                    }}
+                    placeholder="us-east-1"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>
+                    Endpoint {form.s3Provider === "custom" ? "" : "(optional)"}
+                  </Label>
+                  <Input
+                    value={form.endpoint}
+                    onChange={function onChange(event) {
+                      setForm(function update(current) {
+                        return { ...current, endpoint: event.target.value };
+                      });
+                    }}
+                    placeholder={
+                      form.s3Provider === "custom"
+                        ? "https://s3.example.com"
+                        : "https://s3.us-east-1.amazonaws.com"
+                    }
+                  />
+                </div>
+              </div>
+            )}
+
+            <div className="space-y-1 text-xs text-neutral-400">
+              <div>
+                Last run:{" "}
+                {backupConfigQuery.data?.lastRunAt
+                  ? formatDate(backupConfigQuery.data.lastRunAt)
+                  : "never"}
+              </div>
+              <div>
+                Last success:{" "}
+                {backupConfigQuery.data?.lastSuccessAt
+                  ? formatDate(backupConfigQuery.data.lastSuccessAt)
+                  : "never"}
+              </div>
+              {backupConfigQuery.data?.lastError && (
+                <div className="text-red-300">
+                  Last error: {backupConfigQuery.data.lastError}
+                </div>
+              )}
             </div>
           </div>
+        </SettingCard>
+      )}
 
-          <Button
-            type="button"
-            variant="destructive"
-            disabled={
-              restoreBackupPath.trim().length === 0 ||
-              restoreTargetBranchName.trim().length === 0 ||
-              restoreMutation.isPending
-            }
-            onClick={function onClick() {
-              setConfirmRestoreOpen(true);
-            }}
-          >
-            {restoreMutation.isPending ? (
-              <>
-                <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
-                Restoring...
-              </>
-            ) : (
-              "Restore with overwrite"
+      {showRestoreSection && (
+        <SettingCard
+          title="Restore"
+          description="Restore one backup to one branch."
+        >
+          <div className="space-y-3">
+            {listBackupsQuery.isLoading && (
+              <div className="text-sm text-neutral-400">Loading backups...</div>
             )}
-          </Button>
-        </div>
-      </SettingCard>
 
-      <ConfirmDialog
-        open={confirmRestoreOpen}
-        onOpenChange={setConfirmRestoreOpen}
-        title="Restore backup"
-        description={`Restore backup into branch ${restoreTargetBranchName || "target"}? Existing data will be overwritten.`}
-        confirmLabel="Restore"
-        variant="destructive"
-        loading={restoreMutation.isPending}
-        onConfirm={function onConfirm() {
-          void confirmRestore();
-        }}
-      />
+            {listBackupsQuery.data && listBackupsQuery.data.length === 0 && (
+              <div className="text-sm text-neutral-400">No backups found.</div>
+            )}
+
+            <div className="grid gap-3 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Backup</Label>
+                <Select
+                  value={restoreBackupPath || undefined}
+                  onValueChange={function onValueChange(value) {
+                    const backup = listBackupsQuery.data?.find(
+                      function byPath(item) {
+                        return item.backupPath === value;
+                      },
+                    );
+                    if (backup) {
+                      startRestore(backup.backupPath, backup.sourceTargetName);
+                      return;
+                    }
+                    setRestoreBackupPath(value);
+                  }}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select backup" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {listBackupsQuery.data?.map(function renderBackup(backup) {
+                      return (
+                        <SelectItem
+                          key={backup.backupPath}
+                          value={backup.backupPath}
+                        >
+                          {formatBackupLabel(backup)}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                {selectedBackup && (
+                  <div className="text-xs text-neutral-500">
+                    {selectedBackup.backupPath}
+                  </div>
+                )}
+              </div>
+              <div className="space-y-2">
+                <Label>Target branch</Label>
+                <Select
+                  value={restoreTargetBranchName || undefined}
+                  onValueChange={setRestoreTargetBranchName}
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select target branch" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {restoreBranchNames.map(function renderBranch(name) {
+                      return (
+                        <SelectItem key={name} value={name}>
+                          {name}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+              </div>
+            </div>
+
+            <Button
+              type="button"
+              variant="destructive"
+              disabled={
+                restoreBackupPath.trim().length === 0 ||
+                restoreTargetBranchName.trim().length === 0 ||
+                restoreMutation.isPending
+              }
+              onClick={function onClick() {
+                setConfirmRestoreOpen(true);
+              }}
+            >
+              {restoreMutation.isPending ? (
+                <>
+                  <Loader2 className="mr-1.5 h-4 w-4 animate-spin" />
+                  Restoring...
+                </>
+              ) : (
+                "Restore with overwrite"
+              )}
+            </Button>
+          </div>
+        </SettingCard>
+      )}
+
+      {showRestoreSection && (
+        <ConfirmDialog
+          open={confirmRestoreOpen}
+          onOpenChange={setConfirmRestoreOpen}
+          title="Restore backup"
+          description={`Restore backup into branch ${restoreTargetBranchName || "target"}? Existing data will be overwritten.`}
+          confirmLabel="Restore"
+          variant="destructive"
+          loading={restoreMutation.isPending}
+          onConfirm={function onConfirm() {
+            void confirmRestore();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
@@ -76,8 +76,6 @@ interface DatabaseBranchPanelProps {
   parentBranchName: string | null;
   onOpenDatabaseSettings?: () => void;
   onGoToParent?: () => void;
-  defaultEnvironmentNames: string[];
-  isDefaultInCurrentEnvironment: boolean;
   providerRef: DatabaseProviderRef | null;
   onStart: () => Promise<void>;
   onDeploy: () => Promise<void>;
@@ -163,8 +161,6 @@ export function DatabaseBranchPanel({
   parentBranchName,
   onOpenDatabaseSettings,
   onGoToParent,
-  defaultEnvironmentNames,
-  isDefaultInCurrentEnvironment,
   providerRef,
   onStart,
   onDeploy,
@@ -254,39 +250,6 @@ export function DatabaseBranchPanel({
     [runtime, branch?.name],
   );
 
-  const internalConnectionString = useMemo(
-    function getInternalConnectionString() {
-      if (!branch || !providerRef) {
-        return null;
-      }
-
-      if (engine !== "postgres" && !isDefaultInCurrentEnvironment) {
-        return null;
-      }
-
-      return getConnectionString({
-        engine,
-        host:
-          engine === "postgres"
-            ? getDatabaseBranchInternalHost(
-                databaseName,
-                runtime?.hostname ?? branch.name,
-              )
-            : `${databaseName}.frost.internal`,
-        port: engine === "postgres" ? 5432 : 3306,
-        providerRef,
-      });
-    },
-    [
-      branch,
-      databaseName,
-      engine,
-      isDefaultInCurrentEnvironment,
-      providerRef,
-      runtime?.hostname,
-    ],
-  );
-
   const directConnectionString = useMemo(
     function getDirectConnectionString() {
       if (!branch || !providerRef) {
@@ -300,6 +263,30 @@ export function DatabaseBranchPanel({
       });
     },
     [branch, engine, providerRef],
+  );
+
+  const internalConnectionString = useMemo(
+    function getInternalConnectionString() {
+      if (!branch || !providerRef) {
+        return null;
+      }
+
+      const host =
+        engine === "postgres"
+          ? getDatabaseBranchInternalHost(
+              databaseName,
+              runtime?.hostname ?? branch.name,
+            )
+          : `${runtime?.hostname ?? branch.name}.frost.internal`;
+
+      return getConnectionString({
+        engine,
+        host,
+        port: engine === "postgres" ? 5432 : 3306,
+        providerRef,
+      });
+    },
+    [branch, databaseName, engine, providerRef, runtime?.hostname],
   );
 
   const isMainBranch = branch?.name === "main";
@@ -353,13 +340,9 @@ export function DatabaseBranchPanel({
       nextScaleToZeroMinutes <= 24 * 60);
   const scaleToZeroChanged =
     hasRuntime && nextScaleToZeroMinutes !== runtime.scaleToZeroMinutes;
-  const branchAttachedToEnvironment = defaultEnvironmentNames.length > 0;
   let scaleToZeroBlockedReason: string | null = null;
   if (isMainBranch) {
     scaleToZeroBlockedReason = "main cannot use scale to zero.";
-  } else if (branchAttachedToEnvironment) {
-    scaleToZeroBlockedReason =
-      "Detach this branch from environments before enabling scale to zero.";
   }
   const canSaveScaleToZero =
     hasRuntime &&
@@ -611,14 +594,6 @@ export function DatabaseBranchPanel({
                             {getTimeAgo(new Date(branch.createdAt))}
                           </p>
                         </div>
-                        <div className="space-y-1">
-                          <p className="text-xs uppercase tracking-wide text-neutral-500">
-                            Default in envs
-                          </p>
-                          <p className="text-neutral-200">
-                            {defaultEnvironmentNames.length}
-                          </p>
-                        </div>
                       </div>
                     </CardContent>
                   </Card>
@@ -646,17 +621,14 @@ export function DatabaseBranchPanel({
                           </div>
                         ) : (
                           <p className="text-sm text-neutral-500">
-                            Set this{" "}
-                            {engine === "postgres" ? "branch" : "instance"} as
-                            default in this environment to use the internal
-                            alias.
+                            Connection details unavailable.
                           </p>
                         )}
                       </div>
 
                       <div>
                         <p className="mb-1 text-xs text-neutral-500">
-                          Direct host connection
+                          Direct connection
                         </p>
                         {directConnectionString ? (
                           <div className="flex items-start gap-2">

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-card.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-card.tsx
@@ -1,23 +1,14 @@
 "use client";
 
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  type CanvasDatabase,
-  type CanvasDatabaseAttachment,
-  DatabaseContent,
-} from "./database-content";
+import { type CanvasDatabase, DatabaseContent } from "./database-content";
 
 interface DatabaseCardProps {
   database: CanvasDatabase;
-  attachment: CanvasDatabaseAttachment | null;
   onOpen: (databaseId: string) => void;
 }
 
-export function DatabaseCard({
-  database,
-  attachment,
-  onOpen,
-}: DatabaseCardProps) {
+export function DatabaseCard({ database, onOpen }: DatabaseCardProps) {
   return (
     <button
       type="button"
@@ -26,7 +17,7 @@ export function DatabaseCard({
     >
       <Card className="h-full cursor-pointer border-neutral-800 bg-neutral-900 transition-colors hover:border-neutral-700">
         <CardContent className="flex h-full flex-col p-4">
-          <DatabaseContent database={database} attachment={attachment} />
+          <DatabaseContent database={database} />
         </CardContent>
       </Card>
     </button>

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-content.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-content.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { StatusDot } from "@/components/status-dot";
 import { Badge } from "@/components/ui/badge";
 import {
   DATABASE_LOGO_FALLBACK,
@@ -16,22 +15,18 @@ export interface CanvasDatabase {
   provider: "postgres-docker" | "mysql-docker";
 }
 
-export interface CanvasDatabaseAttachment {
-  databaseId: string;
-  targetName: string;
-  targetLifecycleStatus: "active" | "stopped" | "expired";
-  mode: "managed" | "manual";
-}
-
 interface DatabaseContentProps {
   database: CanvasDatabase;
-  attachment: CanvasDatabaseAttachment | null;
 }
 
-export function DatabaseContent({
-  database,
-  attachment,
-}: DatabaseContentProps) {
+function getDatabaseSubtitle(engine: "postgres" | "mysql"): string {
+  if (engine === "postgres") {
+    return "branches managed manually";
+  }
+  return "instances managed manually";
+}
+
+export function DatabaseContent({ database }: DatabaseContentProps) {
   const [logoSrc, setLogoSrc] = useState(getDatabaseLogoUrl(database.engine));
 
   useEffect(
@@ -60,20 +55,11 @@ export function DatabaseContent({
           />
         </div>
         <div className="min-w-0 flex-1">
-          <div className="flex items-center justify-between gap-2">
-            <p className="truncate font-medium text-neutral-200">
-              {database.name}
-            </p>
-            <StatusDot
-              status={attachment?.targetLifecycleStatus ?? "stopped"}
-            />
-          </div>
+          <p className="truncate font-medium text-neutral-200">
+            {database.name}
+          </p>
           <p className="truncate text-xs text-neutral-500">
-            {attachment
-              ? attachment.targetName
-              : database.engine === "postgres"
-                ? "main"
-                : "not attached"}
+            {getDatabaseSubtitle(database.engine)}
           </p>
         </div>
       </div>
@@ -85,9 +71,6 @@ export function DatabaseContent({
         >
           {database.engine}
         </Badge>
-        {attachment && (
-          <span className="text-xs text-neutral-500">{attachment.mode}</span>
-        )}
       </div>
     </>
   );

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
@@ -10,10 +10,7 @@ import { LeftMenuFooter } from "@/components/left-menu-footer";
 import { ProjectPicker } from "@/components/project-picker";
 import { ShellTopRow } from "@/components/shell-top-row";
 import { StatusDot } from "@/components/status-dot";
-import {
-  useDatabases,
-  useEnvironmentDatabaseAttachments,
-} from "@/hooks/use-databases";
+import { useDatabases } from "@/hooks/use-databases";
 import { useProject, useProjects } from "@/hooks/use-projects";
 import { api } from "@/lib/api";
 import {
@@ -119,8 +116,6 @@ export function ProjectLeftMenu({
     enabled: currentEnvId.length > 0,
     refetchInterval: 2000,
   });
-  const { data: databaseAttachments = [] } =
-    useEnvironmentDatabaseAttachments(currentEnvId);
 
   const services = useMemo(
     function getServices() {
@@ -162,17 +157,6 @@ export function ProjectLeftMenu({
       return domainMap;
     },
     [allDomains],
-  );
-
-  const databaseAttachmentById = useMemo(
-    function getDatabaseAttachmentById() {
-      return new Map(
-        databaseAttachments.map(function toEntry(attachment) {
-          return [attachment.databaseId, attachment];
-        }),
-      );
-    },
-    [databaseAttachments],
   );
 
   const hasResources = services.length > 0 || databases.length > 0;
@@ -298,13 +282,6 @@ export function ProjectLeftMenu({
               })}
 
               {databases.map(function renderDatabase(database) {
-                const attachment =
-                  databaseAttachmentById.get(database.id) ?? null;
-                const branchLabel = attachment
-                  ? attachment.targetName
-                  : database.engine === "postgres"
-                    ? "main"
-                    : "not attached";
                 const href = currentEnvId
                   ? `/projects/${projectId}/environments/${currentEnvId}/databases/${database.id}`
                   : `/projects/${projectId}`;
@@ -316,8 +293,8 @@ export function ProjectLeftMenu({
                     iconSrc={getDatabaseLogoUrl(database.engine)}
                     iconFallback={DATABASE_LOGO_FALLBACK}
                     name={database.name}
-                    subtitle={`${database.engine} · ${branchLabel}`}
-                    status={attachment?.targetLifecycleStatus ?? "stopped"}
+                    subtitle={`${database.engine} · manual`}
+                    status="ok"
                   />
                 );
               })}

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/sidebar-settings.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/sidebar-settings.tsx
@@ -1,26 +1,12 @@
 "use client";
 
 import { motion } from "framer-motion";
-import { Loader2, Trash2 } from "lucide-react";
+import { Loader2 } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { EnvVarEditor } from "@/components/env-var-editor";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import {
-  useCreateServiceDatabaseBinding,
-  useDatabases,
-  useDeleteServiceDatabaseBinding,
-  useServiceDatabaseBindings,
-} from "@/hooks/use-databases";
 import { useProject } from "@/hooks/use-projects";
 import { useDeployService, useUpdateService } from "@/hooks/use-services";
 import type { EnvVar, Service } from "@/lib/api";
@@ -106,132 +92,6 @@ function ReadOnlyVar({ name, value }: ReadOnlyVarProps) {
   );
 }
 
-function DatabaseBindingsCard({
-  service,
-  projectId,
-}: {
-  service: Service;
-  projectId: string;
-}) {
-  const { data: databases = [] } = useDatabases(projectId);
-  const { data: bindings = [] } = useServiceDatabaseBindings(service.id);
-  const createBindingMutation = useCreateServiceDatabaseBinding(service.id);
-  const deleteBindingMutation = useDeleteServiceDatabaseBinding(service.id);
-
-  const [envVarKey, setEnvVarKey] = useState("");
-  const [databaseId, setDatabaseId] = useState("");
-
-  async function handleCreateBinding() {
-    const key = envVarKey.trim().toUpperCase();
-    if (!key || !databaseId) return;
-
-    try {
-      await createBindingMutation.mutateAsync({
-        databaseId,
-        envVarKey: key,
-      });
-      setEnvVarKey("");
-      setDatabaseId("");
-      toast.success("Database binding saved");
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to save binding";
-      toast.error(message);
-    }
-  }
-
-  async function handleDeleteBinding(bindingId: string) {
-    try {
-      await deleteBindingMutation.mutateAsync({ bindingId });
-      toast.success("Database binding removed");
-    } catch (error) {
-      const message =
-        error instanceof Error ? error.message : "Failed to remove binding";
-      toast.error(message);
-    }
-  }
-
-  function handleCreateBindingSubmit(event: React.FormEvent<HTMLFormElement>) {
-    event.preventDefault();
-    void handleCreateBinding();
-  }
-
-  return (
-    <SettingCard
-      title="Database bindings"
-      description="Map env var keys to project databases. Frost resolves the current environment target URL at deploy time."
-    >
-      <div className="space-y-3">
-        <form
-          onSubmit={handleCreateBindingSubmit}
-          className="flex flex-col gap-2 md:flex-row"
-        >
-          <Input
-            value={envVarKey}
-            onChange={(event) => setEnvVarKey(event.target.value)}
-            placeholder="DATABASE_URL"
-            className="border-neutral-700 bg-neutral-800 text-neutral-100 md:w-48"
-          />
-          <Select value={databaseId} onValueChange={setDatabaseId}>
-            <SelectTrigger className="border-neutral-700 bg-neutral-800 text-neutral-100 md:w-56">
-              <SelectValue placeholder="Select database" />
-            </SelectTrigger>
-            <SelectContent className="border-neutral-700 bg-neutral-800">
-              {databases.map((database) => (
-                <SelectItem
-                  key={database.id}
-                  value={database.id}
-                  className="text-neutral-100 focus:bg-neutral-700 focus:text-neutral-100"
-                >
-                  {database.name} ({database.engine})
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-          <Button
-            type="submit"
-            disabled={
-              !envVarKey.trim() ||
-              !databaseId ||
-              createBindingMutation.isPending
-            }
-          >
-            Save binding
-          </Button>
-        </form>
-
-        {bindings.length === 0 ? (
-          <p className="text-sm text-neutral-500">No bindings configured.</p>
-        ) : (
-          <div className="space-y-2">
-            {bindings.map((binding) => (
-              <div
-                key={binding.id}
-                className="flex items-center justify-between rounded-md border border-neutral-800 bg-neutral-950/40 px-3 py-2"
-              >
-                <div className="text-sm text-neutral-200">
-                  <span className="font-mono">{binding.envVarKey}</span> {"->"}{" "}
-                  {binding.databaseName} ({binding.databaseEngine})
-                </div>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => handleDeleteBinding(binding.id)}
-                  disabled={deleteBindingMutation.isPending}
-                  className="text-red-400 hover:text-red-300"
-                >
-                  <Trash2 className="h-4 w-4" />
-                </Button>
-              </div>
-            ))}
-          </div>
-        )}
-      </div>
-    </SettingCard>
-  );
-}
-
 function VariablesTab({
   service,
   projectId,
@@ -309,8 +169,6 @@ function VariablesTab({
           managedKeySettingsUrl={runtimeSettingsUrl}
         />
       </SettingCard>
-
-      <DatabaseBindingsCard service={service} projectId={projectId} />
 
       <SettingCard
         title="Project Environment Variables"

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/[targetId]/layout.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/[targetId]/layout.tsx
@@ -7,11 +7,9 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import {
   useDatabase,
-  useDatabaseAttachments,
   useDatabaseTargets,
   useDeleteDatabaseTarget,
   useDeployDatabaseTarget,
-  useEnvironmentDatabaseAttachments,
   usePatchDatabaseTargetRuntimeSettings,
   useResetDatabaseTarget,
   useStartDatabaseTarget,
@@ -92,9 +90,6 @@ export default function DatabaseBranchDetailLayout({
 
   const { data: database } = useDatabase(databaseId);
   const { data: targets = [] } = useDatabaseTargets(databaseId);
-  const { data: attachments = [] } = useDatabaseAttachments(databaseId);
-  const { data: envAttachments = [] } =
-    useEnvironmentDatabaseAttachments(envId);
 
   const startTargetMutation = useStartDatabaseTarget(databaseId);
   const deployTargetMutation = useDeployDatabaseTarget(databaseId, branchId);
@@ -144,22 +139,6 @@ export default function DatabaseBranchDetailLayout({
       return parseProviderRef(branch.providerRefJson);
     },
     [branch],
-  );
-
-  const defaultEnvironmentNames = useMemo(
-    function getDefaultEnvironmentNames() {
-      if (!branch) {
-        return [];
-      }
-      return attachments
-        .filter((attachment) => attachment.targetId === branch.id)
-        .map((attachment) => attachment.environmentName);
-    },
-    [attachments, branch],
-  );
-
-  const envAttachment = envAttachments.find(
-    (attachment) => attachment.databaseId === databaseId,
   );
 
   const activeTab = getActiveTab(pathname, branchBasePath);
@@ -215,8 +194,6 @@ export default function DatabaseBranchDetailLayout({
               }
             : undefined
         }
-        defaultEnvironmentNames={defaultEnvironmentNames}
-        isDefaultInCurrentEnvironment={envAttachment?.targetId === branch.id}
         providerRef={branchProviderRef}
         onStart={async function onStart() {
           try {

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/page.tsx
@@ -33,7 +33,6 @@ import {
 import {
   useCreateDatabaseTarget,
   useDatabase,
-  useDatabaseAttachments,
   useDatabaseTargets,
   useDeleteDatabaseTarget,
   useResetDatabaseTarget,
@@ -125,7 +124,6 @@ export default function DatabaseBranchesPage() {
 
   const { data: database } = useDatabase(databaseId);
   const { data: targets = [] } = useDatabaseTargets(databaseId);
-  const { data: attachments = [] } = useDatabaseAttachments(databaseId);
 
   const createTargetMutation = useCreateDatabaseTarget(databaseId, projectId);
   const resetTargetMutation = useResetDatabaseTarget(databaseId);
@@ -142,11 +140,6 @@ export default function DatabaseBranchesPage() {
     onSuccess: async function onSuccess() {
       await queryClient.refetchQueries({
         queryKey: orpc.databases.listTargets.key({ input: { databaseId } }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listDatabaseAttachments.key({
-          input: { databaseId },
-        }),
       });
     },
   });
@@ -170,24 +163,6 @@ export default function DatabaseBranchesPage() {
     [targets],
   );
 
-  const attachmentNamesByTargetId = useMemo(
-    function getAttachmentNamesByTargetId() {
-      const map = new Map<string, string[]>();
-      for (const attachment of attachments) {
-        const envNames = map.get(attachment.targetId) ?? [];
-        envNames.push(attachment.environmentName);
-        map.set(attachment.targetId, envNames);
-      }
-      for (const envNames of map.values()) {
-        envNames.sort(function sortEnvNames(a, b) {
-          return a.localeCompare(b);
-        });
-      }
-      return map;
-    },
-    [attachments],
-  );
-
   const rows = useMemo(
     function getRows() {
       const hierarchy = getHierarchyOrder(targets);
@@ -195,7 +170,6 @@ export default function DatabaseBranchesPage() {
         target: (typeof targets)[number];
         depth: number;
         parentName: string | null;
-        attachedEnvNames: string[];
       }> = [];
       for (const item of hierarchy) {
         const target = targetById.get(item.id);
@@ -209,12 +183,11 @@ export default function DatabaseBranchesPage() {
           target,
           depth: item.depth,
           parentName,
-          attachedEnvNames: attachmentNamesByTargetId.get(target.id) ?? [],
         });
       }
       return nextRows;
     },
-    [attachmentNamesByTargetId, targetById, targets],
+    [targetById, targets],
   );
 
   const renameTarget = renameTargetId ? targetById.get(renameTargetId) : null;
@@ -381,7 +354,6 @@ export default function DatabaseBranchesPage() {
                     <th className="px-4 py-3 font-medium">Name</th>
                     <th className="px-4 py-3 font-medium">Parent</th>
                     <th className="px-4 py-3 font-medium">Status</th>
-                    <th className="px-4 py-3 font-medium">Attached envs</th>
                     <th className="px-4 py-3 font-medium">Created</th>
                     <th className="px-4 py-3 font-medium" />
                   </tr>
@@ -439,11 +411,6 @@ export default function DatabaseBranchesPage() {
                           >
                             {row.target.lifecycleStatus}
                           </Badge>
-                        </td>
-                        <td className="px-4 py-3 text-neutral-400">
-                          {row.attachedEnvNames.length === 0
-                            ? "-"
-                            : row.attachedEnvNames.join(", ")}
                         </td>
                         <td className="px-4 py-3 text-neutral-400">
                           {formatDate(row.target.createdAt)}

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/settings/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/settings/page.tsx
@@ -1,24 +1,31 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { useParams, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { ConfirmDialog } from "@/components/confirm-dialog";
 import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
 import {
   useDatabase,
   useDatabaseTargets,
   useDeleteDatabase,
+  useUpdateDatabase,
 } from "@/hooks/use-databases";
 import { DatabaseBackupSettingsPanel } from "../../../../../_components/database-backup-settings-panel";
 
-type DatabaseSettingsTab = "general";
+type DatabaseSettingsTab = "general" | "backup" | "restore";
 
 const DATABASE_SETTINGS_NAV_ITEMS: {
   id: DatabaseSettingsTab;
   label: string;
-}[] = [{ id: "general", label: "General" }];
+}[] = [
+  { id: "general", label: "General" },
+  { id: "backup", label: "Backup" },
+  { id: "restore", label: "Restore" },
+];
 
 export default function DatabaseSettingsPage() {
   const params = useParams();
@@ -30,8 +37,24 @@ export default function DatabaseSettingsPage() {
   const { data: database } = useDatabase(databaseId);
   const { data: targets = [] } = useDatabaseTargets(databaseId);
   const deleteMutation = useDeleteDatabase(projectId);
+  const updateMutation = useUpdateDatabase(databaseId, projectId);
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
   const [activeTab, setActiveTab] = useState<DatabaseSettingsTab>("general");
+  const [name, setName] = useState("");
+  const initialName = useRef("");
+
+  useEffect(
+    function syncName() {
+      if (!database) {
+        return;
+      }
+      setName(database.name);
+      initialName.current = database.name;
+    },
+    [database],
+  );
+
+  const hasNameChanges = name.trim() !== initialName.current;
 
   async function handleDelete() {
     if (!database) {
@@ -45,6 +68,31 @@ export default function DatabaseSettingsPage() {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Failed to delete database";
+      toast.error(message);
+    }
+  }
+
+  async function handleSaveName() {
+    if (!database) {
+      return;
+    }
+
+    const nextName = name.trim();
+    if (nextName.length === 0) {
+      toast.error("Name is required");
+      return;
+    }
+
+    try {
+      await updateMutation.mutateAsync({
+        name: nextName,
+      });
+      setName(nextName);
+      initialName.current = nextName;
+      toast.success("Database name updated");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to update database";
       toast.error(message);
     }
   }
@@ -80,26 +128,86 @@ export default function DatabaseSettingsPage() {
       <div className="flex-1 space-y-6">
         {activeTab === "general" && (
           <>
-            {database.engine === "postgres" && (
-              <DatabaseBackupSettingsPanel
-                databaseId={database.id}
-                targets={targets}
+            <SettingCard
+              title="Database Name"
+              description="Display name for this database."
+              onSubmit={handleSaveName}
+              footerRight={
+                <Button
+                  size="sm"
+                  type="submit"
+                  disabled={updateMutation.isPending || !hasNameChanges}
+                >
+                  {updateMutation.isPending ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    "Save"
+                  )}
+                </Button>
+              }
+            >
+              <Input
+                value={name}
+                onChange={function onNameChange(event) {
+                  setName(event.target.value);
+                }}
+                placeholder="my-database"
               />
-            )}
+            </SettingCard>
 
             <SettingCard
               title="Delete Database"
-              description="This removes all targets, attachments, and bindings for this database."
+              description="This removes all targets for this database."
             >
               <Button
                 variant="destructive"
-                onClick={() => setDeleteDialogOpen(true)}
+                onClick={function onDeleteClick() {
+                  setDeleteDialogOpen(true);
+                }}
                 disabled={deleteMutation.isPending}
               >
                 Delete database
               </Button>
             </SettingCard>
           </>
+        )}
+
+        {activeTab === "backup" && database.engine === "postgres" && (
+          <DatabaseBackupSettingsPanel
+            databaseId={database.id}
+            targets={targets}
+            mode="backup"
+          />
+        )}
+
+        {activeTab === "backup" && database.engine !== "postgres" && (
+          <SettingCard
+            title="Backups"
+            description="Backups are available for postgres databases only."
+          >
+            <div className="text-sm text-neutral-400">
+              This database engine does not support backup settings.
+            </div>
+          </SettingCard>
+        )}
+
+        {activeTab === "restore" && database.engine === "postgres" && (
+          <DatabaseBackupSettingsPanel
+            databaseId={database.id}
+            targets={targets}
+            mode="restore"
+          />
+        )}
+
+        {activeTab === "restore" && database.engine !== "postgres" && (
+          <SettingCard
+            title="Restore"
+            description="Restore is available for postgres databases only."
+          >
+            <div className="text-sm text-neutral-400">
+              This database engine does not support restore settings.
+            </div>
+          </SettingCard>
         )}
       </div>
 

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/page.tsx
@@ -5,10 +5,7 @@ import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useMemo } from "react";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  useDatabases,
-  useEnvironmentDatabaseAttachments,
-} from "@/hooks/use-databases";
+import { useDatabases } from "@/hooks/use-databases";
 import { api } from "@/lib/api";
 import { orpc } from "@/lib/orpc-client";
 import { getPreferredDomain } from "@/lib/service-url";
@@ -29,8 +26,6 @@ export default function EnvironmentDetailPage() {
 
   const { data: databases = [], isLoading: isDatabasesLoading } =
     useDatabases(projectId);
-  const { data: databaseAttachments = [] } =
-    useEnvironmentDatabaseAttachments(envId);
   const { data: settings } = useQuery({
     queryKey: ["settings"],
     queryFn: function fetchSettings() {
@@ -78,17 +73,6 @@ export default function EnvironmentDetailPage() {
       return domainMap;
     },
     [allDomains],
-  );
-
-  const databaseAttachmentById = useMemo(
-    function getDatabaseAttachmentById() {
-      return new Map(
-        databaseAttachments.map(function toEntry(attachment) {
-          return [attachment.databaseId, attachment];
-        }),
-      );
-    },
-    [databaseAttachments],
   );
 
   const hasResources = services.length > 0 || databases.length > 0;
@@ -200,7 +184,6 @@ export default function EnvironmentDetailPage() {
                 <DatabaseCard
                   key={database.id}
                   database={database}
-                  attachment={databaseAttachmentById.get(database.id) ?? null}
                   onOpen={openDatabase}
                 />
               );

--- a/apps/app/src/app/(workspace)/projects/[id]/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/page.tsx
@@ -2,19 +2,16 @@
 
 import { useQuery } from "@tanstack/react-query";
 import { Layers, Plus, Sparkles } from "lucide-react";
-import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useMemo } from "react";
 import { EmptyState } from "@/components/empty-state";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
-import {
-  useDatabases,
-  useEnvironmentDatabaseAttachments,
-} from "@/hooks/use-databases";
+import { useDatabases } from "@/hooks/use-databases";
 import { api } from "@/lib/api";
 import { orpc } from "@/lib/orpc-client";
 import { getPreferredDomain } from "@/lib/service-url";
+import { useCreateServiceModal } from "../../_components/create-service-modal-provider";
 import { DatabaseCard } from "./_components/database-card";
 import { ServiceCard } from "./_components/service-card";
 
@@ -22,6 +19,7 @@ export default function ProjectStartPage() {
   const params = useParams();
   const projectId = params.id as string;
   const router = useRouter();
+  const { openCreateServiceModal } = useCreateServiceModal();
 
   const { data: environments = [], isLoading: isEnvironmentsLoading } =
     useQuery(orpc.environments.list.queryOptions({ input: { projectId } }));
@@ -43,8 +41,6 @@ export default function ProjectStartPage() {
   });
   const { data: databases = [], isLoading: isDatabasesLoading } =
     useDatabases(projectId);
-  const { data: databaseAttachments = [] } =
-    useEnvironmentDatabaseAttachments(currentEnvId);
   const { data: settings } = useQuery({
     queryKey: ["settings"],
     queryFn: function fetchSettings() {
@@ -92,17 +88,6 @@ export default function ProjectStartPage() {
       return domainMap;
     },
     [allDomains],
-  );
-
-  const databaseAttachmentById = useMemo(
-    function getDatabaseAttachmentById() {
-      return new Map(
-        databaseAttachments.map(function toEntry(attachment) {
-          return [attachment.databaseId, attachment];
-        }),
-      );
-    },
-    [databaseAttachments],
   );
 
   const hasResources = services.length > 0 || databases.length > 0;
@@ -165,11 +150,9 @@ export default function ProjectStartPage() {
               </p>
 
               <div className="mt-8">
-                <Button asChild>
-                  <Link href={`/projects/${projectId}?create=service`}>
-                    <Plus className="h-4 w-4" />
-                    Create first service
-                  </Link>
+                <Button type="button" onClick={openCreateServiceModal}>
+                  <Plus className="h-4 w-4" />
+                  Create first service
                 </Button>
               </div>
             </div>
@@ -213,7 +196,6 @@ export default function ProjectStartPage() {
                 <DatabaseCard
                   key={database.id}
                   database={database}
-                  attachment={databaseAttachmentById.get(database.id) ?? null}
                   onOpen={openDatabase}
                 />
               );

--- a/apps/app/src/app/api/github/webhook/route.ts
+++ b/apps/app/src/app/api/github/webhook/route.ts
@@ -1,9 +1,5 @@
 import { NextResponse } from "next/server";
 import { getSetting } from "@/lib/auth";
-import {
-  cloneEnvironmentDatabaseTargets,
-  ensureEnvironmentPostgresDefaults,
-} from "@/lib/database-runtime";
 import { isDemoMode } from "@/lib/demo-mode";
 import { deployService } from "@/lib/deployer";
 import {
@@ -224,11 +220,6 @@ async function handlePullRequest(rawBody: string) {
     branch,
     prTitle,
   );
-  await cloneEnvironmentDatabaseTargets({
-    sourceEnvironmentId: productionServices[0].environmentId,
-    targetEnvironmentId: environmentId,
-  });
-  await ensureEnvironmentPostgresDefaults(environmentId);
   const envName = slugify(prTitle).substring(0, 50);
 
   const deploymentIds: string[] = [];

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -5,7 +5,6 @@ const databaseEngineSchema = z.enum(["postgres", "mysql"]);
 const databaseProviderSchema = z.enum(["postgres-docker", "mysql-docker"]);
 const databaseTargetKindSchema = z.enum(["branch", "instance"]);
 const databaseTargetLifecycleSchema = z.enum(["active", "stopped", "expired"]);
-const attachmentModeSchema = z.enum(["managed", "manual"]);
 const databaseStorageBackendSchema = z.enum(["apfs", "zfs"]);
 const backupIntervalUnitSchema = z.enum(["minutes", "hours", "days"]);
 const backupS3ProviderSchema = z.enum([
@@ -102,41 +101,6 @@ const databaseWithMainTargetSchema = z.object({
   target: databaseTargetSchema,
 });
 
-const environmentAttachmentSchema = z.object({
-  id: z.string(),
-  environmentId: z.string(),
-  databaseId: z.string(),
-  targetId: z.string(),
-  mode: attachmentModeSchema,
-  createdAt: z.number(),
-  databaseName: z.string(),
-  databaseEngine: databaseEngineSchema,
-  targetName: z.string(),
-  targetLifecycleStatus: databaseTargetLifecycleSchema,
-});
-
-const databaseAttachmentSchema = z.object({
-  id: z.string(),
-  environmentId: z.string(),
-  databaseId: z.string(),
-  targetId: z.string(),
-  mode: attachmentModeSchema,
-  createdAt: z.number(),
-  environmentName: z.string(),
-  environmentType: z.enum(["production", "preview", "manual"]),
-  targetName: z.string(),
-});
-
-const serviceBindingSchema = z.object({
-  id: z.string(),
-  serviceId: z.string(),
-  databaseId: z.string(),
-  envVarKey: z.string(),
-  createdAt: z.number(),
-  databaseName: z.string(),
-  databaseEngine: databaseEngineSchema,
-});
-
 const databaseBackupConfigSchema = z.object({
   databaseId: z.string(),
   enabled: z.boolean(),
@@ -224,6 +188,16 @@ export const databasesContract = {
   get: oc
     .route({ method: "GET", path: "/databases/{databaseId}" })
     .input(z.object({ databaseId: z.string() }))
+    .output(databaseSchema),
+
+  patch: oc
+    .route({ method: "PATCH", path: "/databases/{databaseId}" })
+    .input(
+      z.object({
+        databaseId: z.string(),
+        name: z.string().min(1).optional(),
+      }),
+    )
     .output(databaseSchema),
 
   getBackup: oc
@@ -547,64 +521,4 @@ export const databasesContract = {
     })
     .input(targetParamsSchema)
     .output(z.array(databaseTargetDeploymentSchema)),
-
-  putAttachment: oc
-    .route({
-      method: "PUT",
-      path: "/environments/{envId}/databases/{databaseId}/attachment",
-    })
-    .input(
-      z.object({
-        envId: z.string(),
-        databaseId: z.string(),
-        targetId: z.string(),
-        mode: attachmentModeSchema,
-      }),
-    )
-    .output(z.object({ success: z.boolean() })),
-
-  listEnvironmentAttachments: oc
-    .route({
-      method: "GET",
-      path: "/environments/{envId}/database-attachments",
-    })
-    .input(z.object({ envId: z.string() }))
-    .output(z.array(environmentAttachmentSchema)),
-
-  deleteAttachment: oc
-    .route({
-      method: "DELETE",
-      path: "/environments/{envId}/databases/{databaseId}/attachment",
-    })
-    .input(z.object({ envId: z.string(), databaseId: z.string() }))
-    .output(z.object({ success: z.boolean() })),
-
-  createServiceBinding: oc
-    .route({ method: "POST", path: "/services/{serviceId}/database-bindings" })
-    .input(
-      z.object({
-        serviceId: z.string(),
-        databaseId: z.string(),
-        envVarKey: z.string().min(1),
-      }),
-    )
-    .output(z.object({ success: z.boolean() })),
-
-  listServiceBindings: oc
-    .route({ method: "GET", path: "/services/{serviceId}/database-bindings" })
-    .input(z.object({ serviceId: z.string() }))
-    .output(z.array(serviceBindingSchema)),
-
-  deleteServiceBinding: oc
-    .route({
-      method: "DELETE",
-      path: "/services/{serviceId}/database-bindings/{bindingId}",
-    })
-    .input(z.object({ serviceId: z.string(), bindingId: z.string() }))
-    .output(z.object({ success: z.boolean() })),
-
-  listDatabaseAttachments: oc
-    .route({ method: "GET", path: "/databases/{databaseId}/attachments" })
-    .input(z.object({ databaseId: z.string() }))
-    .output(z.array(databaseAttachmentSchema)),
 };

--- a/apps/app/src/hooks/use-databases.ts
+++ b/apps/app/src/hooks/use-databases.ts
@@ -16,6 +16,23 @@ export function useDatabase(databaseId: string) {
   });
 }
 
+export function useUpdateDatabase(databaseId: string, projectId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (
+      data: Omit<ContractInputs["databases"]["patch"], "databaseId">,
+    ) => orpc.databases.patch.call({ databaseId, ...data }),
+    onSuccess: async () => {
+      await queryClient.refetchQueries({
+        queryKey: orpc.databases.get.key({ input: { databaseId } }),
+      });
+      await queryClient.refetchQueries({
+        queryKey: orpc.databases.list.key({ input: { projectId } }),
+      });
+    },
+  });
+}
+
 export function useDatabaseBackupConfig(databaseId: string) {
   return useQuery({
     ...orpc.databases.getBackup.queryOptions({ input: { databaseId } }),
@@ -74,24 +91,6 @@ export function useRunDatabaseTargetSql(databaseId: string, targetId: string) {
         ...data,
       });
     },
-  });
-}
-
-export function useDatabaseAttachments(databaseId: string) {
-  return useQuery({
-    ...orpc.databases.listDatabaseAttachments.queryOptions({
-      input: { databaseId },
-    }),
-    enabled: !!databaseId,
-  });
-}
-
-export function useEnvironmentDatabaseAttachments(envId: string) {
-  return useQuery({
-    ...orpc.databases.listEnvironmentAttachments.queryOptions({
-      input: { envId },
-    }),
-    enabled: !!envId,
   });
 }
 
@@ -205,11 +204,6 @@ export function useCreateDatabaseTarget(databaseId: string, projectId: string) {
       await queryClient.refetchQueries({
         queryKey: orpc.databases.list.key({ input: { projectId } }),
       });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listDatabaseAttachments.key({
-          input: { databaseId },
-        }),
-      });
     },
   });
 }
@@ -263,11 +257,6 @@ export function useDeleteDatabaseTarget(databaseId: string) {
       await queryClient.refetchQueries({
         queryKey: orpc.databases.listTargets.key({ input: { databaseId } }),
       });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listDatabaseAttachments.key({
-          input: { databaseId },
-        }),
-      });
     },
   });
 }
@@ -320,101 +309,6 @@ export function usePatchDatabaseTargetRuntimeSettings(
       await queryClient.refetchQueries({
         queryKey: orpc.databases.listTargetDeployments.key({
           input: { databaseId, targetId },
-        }),
-      });
-    },
-  });
-}
-
-export function usePutEnvironmentDatabaseAttachment(
-  envId: string,
-  databaseId: string,
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (
-      data: Omit<
-        ContractInputs["databases"]["putAttachment"],
-        "envId" | "databaseId"
-      >,
-    ) => orpc.databases.putAttachment.call({ envId, databaseId, ...data }),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listEnvironmentAttachments.key({
-          input: { envId },
-        }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.environments.get.key({ input: { envId } }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listTargets.key({ input: { databaseId } }),
-      });
-    },
-  });
-}
-
-export function useDeleteEnvironmentDatabaseAttachment(
-  envId: string,
-  databaseId: string,
-) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: () =>
-      orpc.databases.deleteAttachment.call({ envId, databaseId }),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listEnvironmentAttachments.key({
-          input: { envId },
-        }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.environments.get.key({ input: { envId } }),
-      });
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listTargets.key({ input: { databaseId } }),
-      });
-    },
-  });
-}
-
-export function useServiceDatabaseBindings(serviceId: string) {
-  return useQuery({
-    ...orpc.databases.listServiceBindings.queryOptions({
-      input: { serviceId },
-    }),
-    enabled: !!serviceId,
-  });
-}
-
-export function useCreateServiceDatabaseBinding(serviceId: string) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: (
-      data: Omit<
-        ContractInputs["databases"]["createServiceBinding"],
-        "serviceId"
-      >,
-    ) => orpc.databases.createServiceBinding.call({ serviceId, ...data }),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listServiceBindings.key({
-          input: { serviceId },
-        }),
-      });
-    },
-  });
-}
-
-export function useDeleteServiceDatabaseBinding(serviceId: string) {
-  const queryClient = useQueryClient();
-  return useMutation({
-    mutationFn: ({ bindingId }: { bindingId: string }) =>
-      orpc.databases.deleteServiceBinding.call({ serviceId, bindingId }),
-    onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: orpc.databases.listServiceBindings.key({
-          input: { serviceId },
         }),
       });
     },

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -3,6 +3,7 @@ import { randomBytes } from "node:crypto";
 import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { nanoid } from "nanoid";
+import { getDatabaseBranchAlias } from "./database-hostname";
 import {
   type DatabaseProvider,
   normalizeDatabaseProvider,
@@ -16,8 +17,12 @@ import type {
   Databases,
   DatabaseTargetDeployments,
   DatabaseTargets,
+  Environments,
 } from "./db-types";
 import {
+  connectContainerToNetwork,
+  createNetwork,
+  disconnectContainerFromNetwork,
   getAvailablePort,
   isPortConflictError,
   runContainer,
@@ -729,6 +734,123 @@ async function getTargetByName(
   return target;
 }
 
+function buildNetworkName(environment: Selectable<Environments>): string {
+  return sanitizeDockerName(
+    `frost-net-${environment.projectId}-${environment.id}`,
+  );
+}
+
+function getBaseAliases(databaseName: string): string[] {
+  return [databaseName, `${databaseName}.frost.internal`];
+}
+
+function getTargetAliases(input: {
+  databaseName: string;
+  targetHostname: string;
+  includeBaseAliases: boolean;
+}): string[] {
+  const branchAlias = getDatabaseBranchAlias(
+    input.databaseName,
+    input.targetHostname,
+  );
+  const aliases = [branchAlias, `${branchAlias}.frost.internal`];
+  if (input.includeBaseAliases) {
+    aliases.push(...getBaseAliases(input.databaseName));
+  }
+  return aliases;
+}
+
+async function ensurePostgresDatabaseNetworkAttachment(input: {
+  environment: Selectable<Environments>;
+  database: Selectable<Databases>;
+}): Promise<void> {
+  const targets = await db
+    .selectFrom("databaseTargets")
+    .selectAll()
+    .where("databaseId", "=", input.database.id)
+    .execute();
+
+  if (targets.length === 0) {
+    return;
+  }
+
+  const mainTargetId =
+    targets.find((target) => target.name === "main")?.id ?? targets[0]?.id;
+
+  const networkName = buildNetworkName(input.environment);
+  await createNetwork(networkName, {
+    "frost.managed": "true",
+    "frost.project.id": input.environment.projectId,
+  });
+
+  for (const target of targets) {
+    const providerRef = parseProviderRef(target.providerRefJson);
+    await disconnectContainerFromNetwork(
+      providerRef.containerName,
+      networkName,
+    );
+  }
+
+  for (const target of targets) {
+    const providerRef = parseProviderRef(target.providerRefJson);
+    await connectContainerToNetwork(
+      providerRef.containerName,
+      networkName,
+      getTargetAliases({
+        databaseName: input.database.name,
+        targetHostname: target.hostname,
+        includeBaseAliases: target.id === mainTargetId,
+      }),
+    );
+  }
+}
+
+async function reconnectPostgresDatabaseNetwork(
+  database: Selectable<Databases>,
+): Promise<void> {
+  if (database.engine !== "postgres") {
+    return;
+  }
+
+  const environments = await db
+    .selectFrom("environments")
+    .selectAll()
+    .where("projectId", "=", database.projectId)
+    .execute();
+
+  for (const environment of environments) {
+    await ensurePostgresDatabaseNetworkAttachment({ environment, database });
+  }
+}
+
+export async function ensureEnvironmentPostgresNetworkAccess(
+  environmentId: string,
+): Promise<void> {
+  const environment = await db
+    .selectFrom("environments")
+    .selectAll()
+    .where("id", "=", environmentId)
+    .executeTakeFirst();
+
+  if (!environment) {
+    throw new Error("Environment not found");
+  }
+
+  const databases = await db
+    .selectFrom("databases")
+    .selectAll()
+    .where("projectId", "=", environment.projectId)
+    .where("engine", "=", "postgres")
+    .execute();
+
+  for (const database of databases) {
+    await ensurePostgresDatabaseNetworkAttachment({
+      environment,
+      database: normalizeDatabase(database),
+    });
+  }
+}
+
 function isScaleToZeroEnabled(
   target: Pick<DatabaseTargets, "scaleToZeroMinutes">,
 ): boolean {
@@ -906,6 +1028,11 @@ export async function createDatabase(input: {
       message: "Target created",
     });
 
+    if (input.engine === "postgres") {
+      const createdDatabase = await getDatabaseById(databaseId);
+      await reconnectPostgresDatabaseNetwork(createdDatabase);
+    }
+
     rollback.clear();
   } catch (error) {
     await rollback.run();
@@ -1037,6 +1164,9 @@ export async function createDatabaseTarget(input: {
   }
 
   const target = await getTargetById(targetId);
+  if (database.engine === "postgres") {
+    await reconnectPostgresDatabaseNetwork(database);
+  }
   return target;
 }
 
@@ -1122,6 +1252,7 @@ export async function resetDatabaseTarget(input: {
       fixedHostPort: getTargetRuntimeHostPort(target, currentRef),
       storageMountPath: liveMountPath,
     });
+    await waitForPostgresReady(nextRef);
   } catch (error) {
     const message =
       error instanceof Error ? error.message : "Reset failed while starting";
@@ -1166,6 +1297,7 @@ export async function resetDatabaseTarget(input: {
 
   const updated = await getTargetById(target.id);
   await ensureTargetGateway(updated.id);
+  await reconnectPostgresDatabaseNetwork(database);
   return updated;
 }
 
@@ -1185,6 +1317,9 @@ export async function startDatabaseTarget(input: {
     providerRef,
     fixedHostPort: runtimeHostPort,
   });
+  if (database.engine === "postgres") {
+    await waitForPostgresReady(nextRef);
+  }
   applyProviderRefRuntimePorts({
     target,
     previousProviderRef: providerRef,
@@ -1210,6 +1345,7 @@ export async function startDatabaseTarget(input: {
 
   const updated = await getTargetById(target.id);
   await ensureTargetGateway(updated.id);
+  await reconnectPostgresDatabaseNetwork(database);
   return updated;
 }
 
@@ -1323,7 +1459,11 @@ export async function patchDatabase(input: {
     .where("id", "=", database.id)
     .execute();
 
-  return getDatabaseById(database.id);
+  const updated = await getDatabaseById(database.id);
+  if (updated.engine === "postgres") {
+    await reconnectPostgresDatabaseNetwork(updated);
+  }
+  return updated;
 }
 
 export async function cleanupEnvironmentAttachments(
@@ -1362,6 +1502,9 @@ export async function deployDatabaseTarget(
       providerRef,
       fixedHostPort: runtimeHostPort,
     });
+    if (database.engine === "postgres") {
+      await waitForPostgresReady(nextRef);
+    }
     applyProviderRefRuntimePorts({
       target,
       previousProviderRef: providerRef,
@@ -1379,6 +1522,9 @@ export async function deployDatabaseTarget(
       .execute();
 
     await ensureTargetGateway(target.id);
+    if (database.engine === "postgres") {
+      await reconnectPostgresDatabaseNetwork(database);
+    }
 
     return recordTargetDeployment({
       targetId: target.id,
@@ -1778,6 +1924,13 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
       databaseId: target.databaseId,
       targetId: target.id,
     });
+  }
+
+  if (
+    database.engine === "postgres" &&
+    (nameChanged || hostnameChanged || scaleToZeroChanged)
+  ) {
+    await reconnectPostgresDatabaseNetwork(database);
   }
 
   return getDatabaseTargetRuntime(target.id);

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -3,7 +3,6 @@ import { randomBytes } from "node:crypto";
 import { promisify } from "node:util";
 import type { Selectable } from "kysely";
 import { nanoid } from "nanoid";
-import { getDatabaseBranchAlias } from "./database-hostname";
 import {
   type DatabaseProvider,
   normalizeDatabaseProvider,
@@ -17,13 +16,8 @@ import type {
   Databases,
   DatabaseTargetDeployments,
   DatabaseTargets,
-  Environments,
-  Services,
 } from "./db-types";
 import {
-  connectContainerToNetwork,
-  createNetwork,
-  disconnectContainerFromNetwork,
   getAvailablePort,
   isPortConflictError,
   runContainer,
@@ -34,9 +28,7 @@ import {
   newDatabaseId,
   newDatabaseTargetDeploymentId,
   newDatabaseTargetId,
-  newEnvironmentDatabaseAttachmentId,
   newRuntimeServiceId,
-  newServiceDatabaseBindingId,
 } from "./id";
 import type { BranchStorageBackendName } from "./postgres-branching/branch-storage-backend";
 import {
@@ -59,7 +51,6 @@ const execAsync = promisify(exec);
 export type DatabaseEngine = "postgres" | "mysql";
 export type DatabaseTargetKind = "branch" | "instance";
 export type DatabaseTargetLifecycle = "active" | "stopped" | "expired";
-export type AttachmentMode = "managed" | "manual";
 export type DatabaseTargetDeploymentAction =
   | "create"
   | "deploy"
@@ -130,7 +121,6 @@ export interface DatabaseTargetSqlResult {
 
 const DATABASE_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,46}[a-z0-9])?$/;
 const TARGET_NAME_PATTERN = /^[a-z0-9]([a-z0-9-]{0,60}[a-z0-9])?$/;
-const ENV_VAR_KEY_PATTERN = /^[A-Z_][A-Z0-9_]*$/;
 const MEMORY_LIMIT_PATTERN = /^\d+[kmg]$/i;
 const POSTGRES_QUERY_MAX_BUFFER_BYTES = 8 * 1024 * 1024;
 const TARGET_ACTIVITY_WRITE_THROTTLE_MS = 5000;
@@ -739,111 +729,6 @@ async function getTargetByName(
   return target;
 }
 
-function buildNetworkName(environment: Selectable<Environments>): string {
-  return sanitizeDockerName(
-    `frost-net-${environment.projectId}-${environment.id}`,
-  );
-}
-
-function getBaseAliases(databaseName: string): string[] {
-  return [databaseName, `${databaseName}.frost.internal`];
-}
-
-function getTargetAliases(input: {
-  databaseName: string;
-  targetHostname: string;
-  includeBaseAliases: boolean;
-}): string[] {
-  const branchAlias = getDatabaseBranchAlias(
-    input.databaseName,
-    input.targetHostname,
-  );
-  const aliases = [branchAlias, `${branchAlias}.frost.internal`];
-  if (input.includeBaseAliases) {
-    aliases.push(...getBaseAliases(input.databaseName));
-  }
-  return aliases;
-}
-
-export async function ensureTargetNetworkAttachment(input: {
-  environment: Selectable<Environments>;
-  database: Selectable<Databases>;
-  target: Selectable<DatabaseTargets>;
-}): Promise<void> {
-  const providerRef = parseProviderRef(input.target.providerRefJson);
-  const networkName = buildNetworkName(input.environment);
-  await createNetwork(networkName, {
-    "frost.managed": "true",
-    "frost.project.id": input.environment.projectId,
-  });
-  await connectContainerToNetwork(providerRef.containerName, networkName, [
-    ...getBaseAliases(input.database.name),
-  ]);
-}
-
-async function ensurePostgresDatabaseNetworkAttachment(input: {
-  environment: Selectable<Environments>;
-  database: Selectable<Databases>;
-  defaultTargetId: string;
-}): Promise<void> {
-  const targets = await db
-    .selectFrom("databaseTargets")
-    .selectAll()
-    .where("databaseId", "=", input.database.id)
-    .execute();
-
-  const networkName = buildNetworkName(input.environment);
-  await createNetwork(networkName, {
-    "frost.managed": "true",
-    "frost.project.id": input.environment.projectId,
-  });
-
-  for (const target of targets) {
-    const providerRef = parseProviderRef(target.providerRefJson);
-    await disconnectContainerFromNetwork(
-      providerRef.containerName,
-      networkName,
-    );
-  }
-
-  for (const target of targets) {
-    const providerRef = parseProviderRef(target.providerRefJson);
-    await connectContainerToNetwork(
-      providerRef.containerName,
-      networkName,
-      getTargetAliases({
-        databaseName: input.database.name,
-        targetHostname: target.hostname,
-        includeBaseAliases: target.id === input.defaultTargetId,
-      }),
-    );
-  }
-}
-
-async function reconnectPostgresDatabaseAttachments(
-  database: Selectable<Databases>,
-): Promise<void> {
-  const envDefaults = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .innerJoin(
-      "environments",
-      "environments.id",
-      "environmentDatabaseAttachments.environmentId",
-    )
-    .selectAll("environments")
-    .select("environmentDatabaseAttachments.targetId as defaultTargetId")
-    .where("environmentDatabaseAttachments.databaseId", "=", database.id)
-    .execute();
-
-  for (const envDefault of envDefaults) {
-    await ensurePostgresDatabaseNetworkAttachment({
-      environment: envDefault,
-      database,
-      defaultTargetId: envDefault.defaultTargetId,
-    });
-  }
-}
-
 function isScaleToZeroEnabled(
   target: Pick<DatabaseTargets, "scaleToZeroMinutes">,
 ): boolean {
@@ -904,21 +789,6 @@ export async function restoreDatabaseTargetGateways(): Promise<void> {
       });
     }
   }
-}
-
-function buildConnectionString(
-  database: Selectable<Databases>,
-  providerRef: ProviderRef,
-): string {
-  const username = encodeURIComponent(providerRef.username);
-  const password = encodeURIComponent(providerRef.password);
-  const dbName = encodeURIComponent(providerRef.database);
-  const host = database.name;
-  if (database.engine === "postgres") {
-    const sslQuery = providerRef.ssl ? "?sslmode=require" : "";
-    return `postgres://${username}:${password}@${host}:5432/${dbName}${sslQuery}`;
-  }
-  return `mysql://${username}:${password}@${host}:3306/${dbName}`;
 }
 
 export async function createDatabase(input: {
@@ -1035,35 +905,6 @@ export async function createDatabase(input: {
       status: "running",
       message: "Target created",
     });
-
-    if (input.engine === "postgres") {
-      const createdDatabase = await getDatabaseById(databaseId);
-      const environments = await db
-        .selectFrom("environments")
-        .selectAll()
-        .where("projectId", "=", input.projectId)
-        .execute();
-
-      for (const environment of environments) {
-        await db
-          .insertInto("environmentDatabaseAttachments")
-          .values({
-            id: newEnvironmentDatabaseAttachmentId(),
-            environmentId: environment.id,
-            databaseId,
-            targetId,
-            mode: "managed",
-            createdAt: Date.now(),
-          })
-          .execute();
-
-        await ensurePostgresDatabaseNetworkAttachment({
-          environment,
-          database: createdDatabase,
-          defaultTargetId: targetId,
-        });
-      }
-    }
 
     rollback.clear();
   } catch (error) {
@@ -1196,39 +1037,7 @@ export async function createDatabaseTarget(input: {
   }
 
   const target = await getTargetById(targetId);
-  if (database.engine === "postgres") {
-    await reconnectPostgresDatabaseAttachments(database);
-  }
   return target;
-}
-
-async function reconnectTargetAttachments(
-  database: Selectable<Databases>,
-  target: Selectable<DatabaseTargets>,
-): Promise<void> {
-  if (database.engine === "postgres") {
-    await reconnectPostgresDatabaseAttachments(database);
-    return;
-  }
-
-  const attachments = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .innerJoin(
-      "environments",
-      "environments.id",
-      "environmentDatabaseAttachments.environmentId",
-    )
-    .selectAll("environments")
-    .where("environmentDatabaseAttachments.targetId", "=", target.id)
-    .execute();
-
-  for (const environment of attachments) {
-    await ensureTargetNetworkAttachment({
-      environment,
-      database,
-      target,
-    });
-  }
 }
 
 export async function resetDatabaseTarget(input: {
@@ -1357,7 +1166,6 @@ export async function resetDatabaseTarget(input: {
 
   const updated = await getTargetById(target.id);
   await ensureTargetGateway(updated.id);
-  await reconnectTargetAttachments(database, updated);
   return updated;
 }
 
@@ -1402,7 +1210,6 @@ export async function startDatabaseTarget(input: {
 
   const updated = await getTargetById(target.id);
   await ensureTargetGateway(updated.id);
-  await reconnectTargetAttachments(database, updated);
   return updated;
 }
 
@@ -1447,16 +1254,6 @@ export async function deleteDatabaseTarget(input: {
     throw new Error("main target cannot be deleted");
   }
 
-  const attachment = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .select("id")
-    .where("targetId", "=", target.id)
-    .executeTakeFirst();
-
-  if (attachment) {
-    throw new Error("Target is attached to one or more environments");
-  }
-
   await stopDatabaseTargetGateway(target.id);
   clearTargetActivityWrite(target.id);
   const providerRef = parseProviderRef(target.providerRefJson);
@@ -1488,290 +1285,53 @@ export async function deleteDatabase(databaseId: string): Promise<void> {
   await db.deleteFrom("databases").where("id", "=", database.id).execute();
 }
 
-export async function putEnvironmentAttachment(input: {
-  environmentId: string;
+export async function patchDatabase(input: {
   databaseId: string;
-  targetId: string;
-  mode: AttachmentMode;
-}): Promise<void> {
-  const environment = await db
-    .selectFrom("environments")
-    .selectAll()
-    .where("id", "=", input.environmentId)
-    .executeTakeFirst();
-
-  if (!environment) {
-    throw new Error("Environment not found");
-  }
-
+  name?: string;
+}): Promise<Selectable<Databases>> {
   const database = await getDatabaseById(input.databaseId);
+  let nextName: string | undefined;
 
-  if (database.projectId !== environment.projectId) {
-    throw new Error("Environment and database must belong to the same project");
-  }
+  if (input.name !== undefined) {
+    const name = input.name.trim();
+    assertDatabaseName(name);
 
-  const target = await getTargetById(input.targetId);
-
-  if (target.databaseId !== database.id) {
-    throw new Error("Target does not belong to the database");
-  }
-
-  if (target.scaleToZeroMinutes !== null) {
-    throw new Error("Cannot attach a target while scale to zero is enabled");
-  }
-
-  if (
-    environment.type === "production" &&
-    database.engine === "postgres" &&
-    target.name !== "main"
-  ) {
-    throw new Error("Production Postgres attachment must use main");
-  }
-
-  const existingAttachment = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .selectAll()
-    .where("environmentId", "=", environment.id)
-    .where("databaseId", "=", database.id)
-    .executeTakeFirst();
-
-  await db
-    .deleteFrom("environmentDatabaseAttachments")
-    .where("environmentId", "=", environment.id)
-    .where("databaseId", "=", database.id)
-    .execute();
-
-  await db
-    .insertInto("environmentDatabaseAttachments")
-    .values({
-      id: newEnvironmentDatabaseAttachmentId(),
-      environmentId: environment.id,
-      databaseId: database.id,
-      targetId: target.id,
-      mode: input.mode,
-      createdAt: Date.now(),
-    })
-    .execute();
-
-  if (database.engine === "postgres") {
-    await ensurePostgresDatabaseNetworkAttachment({
-      environment,
-      database,
-      defaultTargetId: target.id,
-    });
-    return;
-  }
-
-  if (existingAttachment && existingAttachment.targetId !== target.id) {
-    const previousTarget = await db
-      .selectFrom("databaseTargets")
-      .select("providerRefJson")
-      .where("id", "=", existingAttachment.targetId)
-      .executeTakeFirst();
-
-    if (previousTarget) {
-      const previousRef = parseProviderRef(previousTarget.providerRefJson);
-      await disconnectContainerFromNetwork(
-        previousRef.containerName,
-        buildNetworkName(environment),
-      );
-    }
-  }
-
-  await ensureTargetNetworkAttachment({ environment, database, target });
-}
-
-export async function deleteEnvironmentAttachment(input: {
-  environmentId: string;
-  databaseId: string;
-}): Promise<void> {
-  const attachment = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .selectAll()
-    .where("environmentId", "=", input.environmentId)
-    .where("databaseId", "=", input.databaseId)
-    .executeTakeFirst();
-
-  if (!attachment) {
-    return;
-  }
-
-  const [environment, target, database] = await Promise.all([
-    db
-      .selectFrom("environments")
-      .selectAll()
-      .where("id", "=", attachment.environmentId)
-      .executeTakeFirst(),
-    db
-      .selectFrom("databaseTargets")
-      .selectAll()
-      .where("id", "=", attachment.targetId)
-      .executeTakeFirst(),
-    db
+    const existing = await db
       .selectFrom("databases")
-      .selectAll()
-      .where("id", "=", attachment.databaseId)
-      .executeTakeFirst(),
-  ]);
-
-  await db
-    .deleteFrom("environmentDatabaseAttachments")
-    .where("id", "=", attachment.id)
-    .execute();
-
-  if (environment && database && database.engine === "postgres") {
-    const targets = await db
-      .selectFrom("databaseTargets")
-      .select("providerRefJson")
-      .where("databaseId", "=", database.id)
-      .execute();
-    const networkName = buildNetworkName(environment);
-    for (const row of targets) {
-      const providerRef = parseProviderRef(row.providerRefJson);
-      await disconnectContainerFromNetwork(
-        providerRef.containerName,
-        networkName,
-      );
-    }
-
-    if (attachment.mode !== "managed") {
-      return;
-    }
-
-    const remaining = await db
-      .selectFrom("environmentDatabaseAttachments")
       .select("id")
-      .where("targetId", "=", attachment.targetId)
+      .where("projectId", "=", database.projectId)
+      .where("name", "=", name)
+      .where("id", "!=", database.id)
       .executeTakeFirst();
 
-    if (remaining) {
-      return;
+    if (existing) {
+      throw new Error("Database with this name already exists");
     }
 
-    if (!target || target.name === "main") {
-      return;
-    }
-
-    await stopDatabaseTargetGateway(target.id);
-    clearTargetActivityWrite(target.id);
-    const providerRef = parseProviderRef(target.providerRefJson);
-    await stopContainer(providerRef.containerName);
-    await removePostgresStorage(getPostgresStorageMetadata(providerRef));
-    await db
-      .deleteFrom("databaseTargets")
-      .where("id", "=", target.id)
-      .execute();
-    return;
+    nextName = name;
   }
 
-  if (environment && target) {
-    const providerRef = parseProviderRef(target.providerRefJson);
-    await disconnectContainerFromNetwork(
-      providerRef.containerName,
-      buildNetworkName(environment),
-    );
+  if (nextName === undefined) {
+    return database;
   }
 
-  if (attachment.mode !== "managed") {
-    return;
-  }
+  await db
+    .updateTable("databases")
+    .set({
+      name: nextName,
+    })
+    .where("id", "=", database.id)
+    .execute();
 
-  const remaining = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .select("id")
-    .where("targetId", "=", attachment.targetId)
-    .executeTakeFirst();
-
-  if (remaining) {
-    return;
-  }
-
-  if (!target || target.name === "main") {
-    return;
-  }
-
-  await stopDatabaseTargetGateway(target.id);
-  clearTargetActivityWrite(target.id);
-  const providerRef = parseProviderRef(target.providerRefJson);
-  await stopContainer(providerRef.containerName);
-  await db.deleteFrom("databaseTargets").where("id", "=", target.id).execute();
+  return getDatabaseById(database.id);
 }
 
 export async function cleanupEnvironmentAttachments(
   environmentId: string,
 ): Promise<void> {
-  const attachments = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .select(["environmentId", "databaseId"])
+  await db
+    .deleteFrom("environmentDatabaseAttachments")
     .where("environmentId", "=", environmentId)
-    .execute();
-
-  for (const attachment of attachments) {
-    await deleteEnvironmentAttachment(attachment);
-  }
-}
-
-export async function createServiceDatabaseBinding(input: {
-  serviceId: string;
-  databaseId: string;
-  envVarKey: string;
-}): Promise<void> {
-  if (!ENV_VAR_KEY_PATTERN.test(input.envVarKey)) {
-    throw new Error(
-      "envVarKey must be uppercase and use letters, numbers, and underscores",
-    );
-  }
-
-  const service = await db
-    .selectFrom("services")
-    .innerJoin("environments", "environments.id", "services.environmentId")
-    .select(["services.id as serviceId", "environments.projectId as projectId"])
-    .where("services.id", "=", input.serviceId)
-    .executeTakeFirst();
-
-  if (!service) {
-    throw new Error("Service not found");
-  }
-
-  const database = await getDatabaseById(input.databaseId);
-  if (database.projectId !== service.projectId) {
-    throw new Error("Service and database must belong to the same project");
-  }
-
-  const existing = await db
-    .selectFrom("serviceDatabaseBindings")
-    .select("id")
-    .where("serviceId", "=", input.serviceId)
-    .where("envVarKey", "=", input.envVarKey)
-    .executeTakeFirst();
-
-  if (existing) {
-    await db
-      .updateTable("serviceDatabaseBindings")
-      .set({ databaseId: input.databaseId })
-      .where("id", "=", existing.id)
-      .execute();
-    return;
-  }
-
-  await db
-    .insertInto("serviceDatabaseBindings")
-    .values({
-      id: newServiceDatabaseBindingId(),
-      serviceId: input.serviceId,
-      databaseId: input.databaseId,
-      envVarKey: input.envVarKey,
-      createdAt: Date.now(),
-    })
-    .execute();
-}
-
-export async function deleteServiceDatabaseBinding(
-  bindingId: string,
-): Promise<void> {
-  await db
-    .deleteFrom("serviceDatabaseBindings")
-    .where("id", "=", bindingId)
     .execute();
 }
 
@@ -2108,17 +1668,6 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
       (await getTargetById(target.id)).providerRefJson,
     );
     if (nextScaleToZeroMinutes !== null) {
-      const attachment = await db
-        .selectFrom("environmentDatabaseAttachments")
-        .select("id")
-        .where("targetId", "=", target.id)
-        .executeTakeFirst();
-      if (attachment) {
-        throw new Error(
-          "Scale to zero only works for detached branches right now",
-        );
-      }
-
       let runtimeHostPort = target.runtimeHostPort;
       let nextProviderRef = currentProviderRef;
 
@@ -2231,12 +1780,6 @@ export async function patchDatabaseTargetRuntimeSettings(input: {
     });
   }
 
-  if (nameChanged || hostnameChanged) {
-    if (database.engine === "postgres") {
-      await reconnectPostgresDatabaseAttachments(database);
-    }
-  }
-
   return getDatabaseTargetRuntime(target.id);
 }
 
@@ -2279,285 +1822,6 @@ export async function resolveContainerName(input: {
   return parseProviderRef(target.providerRefJson).containerName;
 }
 
-export async function resolveServiceDatabaseEnvVars(input: {
-  serviceId: string;
-  environmentId: string;
-}): Promise<Record<string, string>> {
-  const service = await db
-    .selectFrom("services")
-    .select(["id", "environmentId"])
-    .where("id", "=", input.serviceId)
-    .executeTakeFirst();
-
-  if (!service) {
-    throw new Error("Service not found");
-  }
-
-  if (service.environmentId !== input.environmentId) {
-    throw new Error("Service does not belong to the requested environment");
-  }
-
-  const bindings = await db
-    .selectFrom("serviceDatabaseBindings")
-    .innerJoin(
-      "databases",
-      "databases.id",
-      "serviceDatabaseBindings.databaseId",
-    )
-    .select([
-      "serviceDatabaseBindings.envVarKey",
-      "serviceDatabaseBindings.databaseId",
-      "databases.name as databaseName",
-      "databases.engine as databaseEngine",
-      "databases.projectId as projectId",
-    ])
-    .where("serviceDatabaseBindings.serviceId", "=", input.serviceId)
-    .execute();
-
-  if (bindings.length === 0) {
-    return {};
-  }
-
-  const environment = await db
-    .selectFrom("environments")
-    .selectAll()
-    .where("id", "=", input.environmentId)
-    .executeTakeFirst();
-
-  if (!environment) {
-    throw new Error("Environment not found");
-  }
-
-  const envVars: Record<string, string> = {};
-
-  for (const binding of bindings) {
-    if (binding.projectId !== environment.projectId) {
-      throw new Error("Database binding project mismatch");
-    }
-
-    let attachment = await db
-      .selectFrom("environmentDatabaseAttachments")
-      .selectAll()
-      .where("environmentId", "=", environment.id)
-      .where("databaseId", "=", binding.databaseId)
-      .executeTakeFirst();
-
-    const database = await getDatabaseById(binding.databaseId);
-
-    if (!attachment) {
-      if (database.engine === "postgres") {
-        const mainTarget = await getTargetByName(database.id, "main");
-        await putEnvironmentAttachment({
-          environmentId: environment.id,
-          databaseId: database.id,
-          targetId: mainTarget.id,
-          mode: "managed",
-        });
-        attachment = await db
-          .selectFrom("environmentDatabaseAttachments")
-          .selectAll()
-          .where("environmentId", "=", environment.id)
-          .where("databaseId", "=", binding.databaseId)
-          .executeTakeFirst();
-      } else {
-        throw new Error(
-          `Environment is missing attachment for database ${binding.databaseName}`,
-        );
-      }
-    }
-
-    if (!attachment) {
-      throw new Error("Failed to resolve database default target");
-    }
-
-    let target = await getTargetById(attachment.targetId);
-
-    if (target.lifecycleStatus !== "active") {
-      target = await startDatabaseTarget({
-        databaseId: database.id,
-        targetId: target.id,
-      });
-    }
-
-    const providerRef = parseProviderRef(target.providerRefJson);
-
-    if (database.engine === "postgres") {
-      await ensurePostgresDatabaseNetworkAttachment({
-        environment,
-        database,
-        defaultTargetId: target.id,
-      });
-    } else {
-      await ensureTargetNetworkAttachment({
-        environment,
-        database,
-        target,
-      });
-    }
-
-    envVars[binding.envVarKey] = buildConnectionString(database, providerRef);
-  }
-
-  return envVars;
-}
-
-function buildManagedTargetNameFromEnvironment(
-  environment: Selectable<Environments>,
-): string {
-  if (environment.type === "preview" && environment.prNumber !== null) {
-    return `pr-${environment.prNumber}`;
-  }
-  return slugify(environment.name).slice(0, 62);
-}
-
-export async function cloneEnvironmentDatabaseTargets(input: {
-  sourceEnvironmentId: string;
-  targetEnvironmentId: string;
-}): Promise<void> {
-  const sourceEnvironment = await db
-    .selectFrom("environments")
-    .selectAll()
-    .where("id", "=", input.sourceEnvironmentId)
-    .executeTakeFirst();
-
-  const targetEnvironment = await db
-    .selectFrom("environments")
-    .selectAll()
-    .where("id", "=", input.targetEnvironmentId)
-    .executeTakeFirst();
-
-  if (!sourceEnvironment || !targetEnvironment) {
-    throw new Error("Environment not found");
-  }
-
-  if (sourceEnvironment.projectId !== targetEnvironment.projectId) {
-    throw new Error("Source and target environments must share a project");
-  }
-
-  const sourceAttachments = await db
-    .selectFrom("environmentDatabaseAttachments")
-    .innerJoin(
-      "databases",
-      "databases.id",
-      "environmentDatabaseAttachments.databaseId",
-    )
-    .innerJoin(
-      "databaseTargets",
-      "databaseTargets.id",
-      "environmentDatabaseAttachments.targetId",
-    )
-    .selectAll("environmentDatabaseAttachments")
-    .selectAll("databases")
-    .select([
-      "databaseTargets.id as sourceTargetId",
-      "databaseTargets.name as sourceTargetName",
-    ])
-    .where(
-      "environmentDatabaseAttachments.environmentId",
-      "=",
-      sourceEnvironment.id,
-    )
-    .execute();
-
-  for (const row of sourceAttachments) {
-    const databaseId = row.databaseId;
-    const database = await getDatabaseById(databaseId);
-    const managedTargetName =
-      buildManagedTargetNameFromEnvironment(targetEnvironment);
-
-    let target = await db
-      .selectFrom("databaseTargets")
-      .selectAll()
-      .where("databaseId", "=", databaseId)
-      .where("name", "=", managedTargetName)
-      .executeTakeFirst();
-
-    if (!target) {
-      if (database.engine === "postgres") {
-        target = await createDatabaseTarget({
-          databaseId,
-          name: managedTargetName,
-          sourceTargetName: row.sourceTargetName,
-        });
-      } else {
-        target = await createDatabaseTarget({
-          databaseId,
-          name: managedTargetName,
-        });
-      }
-    }
-
-    await putEnvironmentAttachment({
-      environmentId: targetEnvironment.id,
-      databaseId,
-      targetId: target.id,
-      mode: "managed",
-    });
-  }
-}
-
-export async function ensureEnvironmentPostgresDefaults(
-  environmentId: string,
-): Promise<void> {
-  const environment = await db
-    .selectFrom("environments")
-    .selectAll()
-    .where("id", "=", environmentId)
-    .executeTakeFirst();
-
-  if (!environment) {
-    throw new Error("Environment not found");
-  }
-
-  const databases = await db
-    .selectFrom("databases")
-    .selectAll()
-    .where("projectId", "=", environment.projectId)
-    .where("engine", "=", "postgres")
-    .execute();
-
-  for (const database of databases) {
-    let attachment = await db
-      .selectFrom("environmentDatabaseAttachments")
-      .selectAll()
-      .where("environmentId", "=", environment.id)
-      .where("databaseId", "=", database.id)
-      .executeTakeFirst();
-
-    if (!attachment) {
-      const mainTarget = await getTargetByName(database.id, "main");
-      await db
-        .insertInto("environmentDatabaseAttachments")
-        .values({
-          id: newEnvironmentDatabaseAttachmentId(),
-          environmentId: environment.id,
-          databaseId: database.id,
-          targetId: mainTarget.id,
-          mode: "managed",
-          createdAt: Date.now(),
-        })
-        .execute();
-
-      attachment = await db
-        .selectFrom("environmentDatabaseAttachments")
-        .selectAll()
-        .where("environmentId", "=", environment.id)
-        .where("databaseId", "=", database.id)
-        .executeTakeFirst();
-    }
-
-    if (!attachment) {
-      continue;
-    }
-
-    await ensurePostgresDatabaseNetworkAttachment({
-      environment,
-      database,
-      defaultTargetId: attachment.targetId,
-    });
-  }
-}
-
 export async function listDatabasesByProject(projectId: string) {
   const databases = await db
     .selectFrom("databases")
@@ -2578,102 +1842,6 @@ export async function listDatabaseTargets(databaseId: string) {
     .execute();
 }
 
-export async function listEnvironmentDatabaseAttachments(
-  environmentId: string,
-) {
-  return db
-    .selectFrom("environmentDatabaseAttachments")
-    .innerJoin(
-      "databases",
-      "databases.id",
-      "environmentDatabaseAttachments.databaseId",
-    )
-    .innerJoin(
-      "databaseTargets",
-      "databaseTargets.id",
-      "environmentDatabaseAttachments.targetId",
-    )
-    .selectAll("environmentDatabaseAttachments")
-    .select([
-      "databases.name as databaseName",
-      "databases.engine as databaseEngine",
-      "databaseTargets.name as targetName",
-      "databaseTargets.lifecycleStatus as targetLifecycleStatus",
-    ])
-    .where("environmentDatabaseAttachments.environmentId", "=", environmentId)
-    .orderBy("environmentDatabaseAttachments.createdAt", "asc")
-    .execute();
-}
-
-export async function listServiceDatabaseBindings(serviceId: string) {
-  return db
-    .selectFrom("serviceDatabaseBindings")
-    .innerJoin(
-      "databases",
-      "databases.id",
-      "serviceDatabaseBindings.databaseId",
-    )
-    .selectAll("serviceDatabaseBindings")
-    .select([
-      "databases.name as databaseName",
-      "databases.engine as databaseEngine",
-    ])
-    .where("serviceDatabaseBindings.serviceId", "=", serviceId)
-    .orderBy("serviceDatabaseBindings.createdAt", "asc")
-    .execute();
-}
-
 export async function getDatabase(databaseId: string) {
   return getDatabaseById(databaseId);
-}
-
-export async function listDatabaseAttachments(databaseId: string) {
-  return db
-    .selectFrom("environmentDatabaseAttachments")
-    .innerJoin(
-      "environments",
-      "environments.id",
-      "environmentDatabaseAttachments.environmentId",
-    )
-    .innerJoin(
-      "databaseTargets",
-      "databaseTargets.id",
-      "environmentDatabaseAttachments.targetId",
-    )
-    .select([
-      "environmentDatabaseAttachments.id",
-      "environmentDatabaseAttachments.environmentId",
-      "environmentDatabaseAttachments.databaseId",
-      "environmentDatabaseAttachments.targetId",
-      "environmentDatabaseAttachments.mode",
-      "environmentDatabaseAttachments.createdAt",
-      "environments.name as environmentName",
-      "environments.type as environmentType",
-      "databaseTargets.name as targetName",
-    ])
-    .where("environmentDatabaseAttachments.databaseId", "=", databaseId)
-    .orderBy("environmentDatabaseAttachments.createdAt", "asc")
-    .execute();
-}
-
-export async function assertComputeService(
-  serviceId: string,
-): Promise<Selectable<Services>> {
-  const service = await db
-    .selectFrom("services")
-    .selectAll()
-    .where("id", "=", serviceId)
-    .executeTakeFirst();
-
-  if (!service) {
-    throw new Error("Service not found");
-  }
-
-  if (service.serviceType === "database") {
-    throw new Error(
-      "Database bindings are only supported for compute services",
-    );
-  }
-
-  return service;
 }

--- a/apps/app/src/lib/database-target-policy-scheduler.ts
+++ b/apps/app/src/lib/database-target-policy-scheduler.ts
@@ -123,22 +123,6 @@ async function runTtlPolicy(now: number): Promise<void> {
       continue;
     }
 
-    const attachment = await db
-      .selectFrom("environmentDatabaseAttachments")
-      .select("id")
-      .where("targetId", "=", target.id)
-      .executeTakeFirst();
-
-    if (attachment) {
-      console.log(
-        "[database-target-policy-scheduler] TTL delete skipped for attached target",
-        {
-          targetId: target.id,
-        },
-      );
-      continue;
-    }
-
     try {
       await deleteDatabaseTarget({
         databaseId: target.databaseId,

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -6,7 +6,6 @@ import type { Selectable } from "kysely";
 import { getSetting } from "./auth";
 import { emitBuildLogChunk } from "./build-log-stream";
 import { decrypt } from "./crypto";
-import { resolveServiceDatabaseEnvVars } from "./database-runtime";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
 import {
@@ -1111,11 +1110,7 @@ async function runServiceDeployment(
 
   const projectEnvVars = parseEnvVars(project.envVars);
   const serviceEnvVars = parseEnvVars(service.envVars);
-  const bindingEnvVars = await resolveServiceDatabaseEnvVars({
-    serviceId: service.id,
-    environmentId: environment.id,
-  });
-  const envVars = { ...projectEnvVars, ...serviceEnvVars, ...bindingEnvVars };
+  const envVars = { ...projectEnvVars, ...serviceEnvVars };
   const envVarsList: EnvVar[] = Object.entries(envVars).map(([key, value]) => ({
     key,
     value,
@@ -1758,11 +1753,7 @@ async function runRollbackDeployment(
     ? JSON.parse(sourceDeployment.envVarsSnapshot)
     : [];
   const envVars = Object.fromEntries(envVarsList.map((e) => [e.key, e.value]));
-  const bindingEnvVars = await resolveServiceDatabaseEnvVars({
-    serviceId: service.id,
-    environmentId: environment.id,
-  });
-  const runtimeEnvBase = { ...envVars, ...bindingEnvVars };
+  const runtimeEnvBase = { ...envVars };
 
   try {
     await appendLog(

--- a/apps/app/src/server/databases.ts
+++ b/apps/app/src/server/databases.ts
@@ -1,24 +1,17 @@
 import { ORPCError } from "@orpc/server";
 import {
-  assertComputeService,
   createDatabase,
   createDatabaseTarget,
-  createServiceDatabaseBinding,
   deleteDatabase,
   deleteDatabaseTarget,
-  deleteEnvironmentAttachment,
-  deleteServiceDatabaseBinding,
   deployDatabaseTarget,
   getDatabase,
   getDatabaseTargetRuntime,
-  listDatabaseAttachments,
   listDatabasesByProject,
   listDatabaseTargetDeployments,
   listDatabaseTargets,
-  listEnvironmentDatabaseAttachments,
-  listServiceDatabaseBindings,
+  patchDatabase,
   patchDatabaseTargetRuntimeSettings,
-  putEnvironmentAttachment,
   resetDatabaseTarget,
   runPostgresTargetSql,
   startDatabaseTarget,
@@ -45,11 +38,7 @@ function toApiError(error: unknown) {
   const message =
     error instanceof Error ? error.message : String(error ?? "Unknown error");
 
-  if (
-    message.includes("not found") ||
-    message.includes("not belong") ||
-    message.includes("missing attachment")
-  ) {
+  if (message.includes("not found") || message.includes("not belong")) {
     return new ORPCError("NOT_FOUND", { message });
   }
 
@@ -147,19 +136,6 @@ async function assertBranchPolicyPatchAllowed(input: {
       message: "main cannot use TTL or scale to zero",
     });
   }
-
-  if (enablesScaleToZero) {
-    const attachment = await db
-      .selectFrom("environmentDatabaseAttachments")
-      .select("id")
-      .where("targetId", "=", target.id)
-      .executeTakeFirst();
-    if (attachment) {
-      throw new ORPCError("BAD_REQUEST", {
-        message: "Scale to zero only works for detached branches right now",
-      });
-    }
-  }
 }
 
 export const databases = {
@@ -188,6 +164,14 @@ export const databases = {
   get: os.databases.get.handler(async ({ input }) => {
     try {
       return await getDatabase(input.databaseId);
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  patch: os.databases.patch.handler(async ({ input }) => {
+    try {
+      return await patchDatabase(input);
     } catch (error) {
       throw toApiError(error);
     }
@@ -527,79 +511,6 @@ export const databases = {
       } catch (error) {
         throw toApiError(error);
       }
-    },
-  ),
-
-  putAttachment: os.databases.putAttachment.handler(async ({ input }) => {
-    try {
-      await putEnvironmentAttachment({
-        environmentId: input.envId,
-        databaseId: input.databaseId,
-        targetId: input.targetId,
-        mode: input.mode,
-      });
-      return { success: true };
-    } catch (error) {
-      throw toApiError(error);
-    }
-  }),
-
-  listEnvironmentAttachments: os.databases.listEnvironmentAttachments.handler(
-    async ({ input }) => {
-      return listEnvironmentDatabaseAttachments(input.envId);
-    },
-  ),
-
-  deleteAttachment: os.databases.deleteAttachment.handler(async ({ input }) => {
-    try {
-      await deleteEnvironmentAttachment({
-        environmentId: input.envId,
-        databaseId: input.databaseId,
-      });
-      return { success: true };
-    } catch (error) {
-      throw toApiError(error);
-    }
-  }),
-
-  createServiceBinding: os.databases.createServiceBinding.handler(
-    async ({ input }) => {
-      try {
-        await assertComputeService(input.serviceId);
-        await createServiceDatabaseBinding(input);
-        return { success: true };
-      } catch (error) {
-        throw toApiError(error);
-      }
-    },
-  ),
-
-  listServiceBindings: os.databases.listServiceBindings.handler(
-    async ({ input }) => {
-      return listServiceDatabaseBindings(input.serviceId);
-    },
-  ),
-
-  deleteServiceBinding: os.databases.deleteServiceBinding.handler(
-    async ({ input }) => {
-      const binding = await db
-        .selectFrom("serviceDatabaseBindings")
-        .select(["id", "serviceId"])
-        .where("id", "=", input.bindingId)
-        .executeTakeFirst();
-
-      if (!binding || binding.serviceId !== input.serviceId) {
-        throw new ORPCError("NOT_FOUND", { message: "Binding not found" });
-      }
-
-      await deleteServiceDatabaseBinding(input.bindingId);
-      return { success: true };
-    },
-  ),
-
-  listDatabaseAttachments: os.databases.listDatabaseAttachments.handler(
-    async ({ input }) => {
-      return listDatabaseAttachments(input.databaseId);
     },
   ),
 };

--- a/apps/app/src/server/environments.ts
+++ b/apps/app/src/server/environments.ts
@@ -1,8 +1,4 @@
 import { ORPCError } from "@orpc/server";
-import {
-  cloneEnvironmentDatabaseTargets,
-  ensureEnvironmentPostgresDefaults,
-} from "@/lib/database-runtime";
 import { db } from "@/lib/db";
 import { deployEnvironment } from "@/lib/deployer";
 import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
@@ -147,18 +143,11 @@ export const environments = {
           });
         }
 
-        await cloneEnvironmentDatabaseTargets({
-          sourceEnvironmentId: sourceEnv.id,
-          targetEnvironmentId: id,
-        });
-
         if (sourceServices.length > 0) {
           shouldDeploy = true;
         }
       }
     }
-
-    await ensureEnvironmentPostgresDefaults(id);
 
     const environment = await db
       .selectFrom("environments")

--- a/apps/app/src/server/environments.ts
+++ b/apps/app/src/server/environments.ts
@@ -1,4 +1,5 @@
 import { ORPCError } from "@orpc/server";
+import { ensureEnvironmentPostgresNetworkAccess } from "@/lib/database-runtime";
 import { db } from "@/lib/db";
 import { deployEnvironment } from "@/lib/deployer";
 import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
@@ -160,6 +161,8 @@ export const environments = {
         message: "Failed to create environment",
       });
     }
+
+    await ensureEnvironmentPostgresNetworkAccess(id);
 
     if (shouldDeploy) {
       deployEnvironment(id).catch(console.error);


### PR DESCRIPTION
## Summary
- remove database binding/attachment UI and API flow from services/env/database pages
- remove deploy-time database binding env var injection and related runtime helpers
- add internal connection string to branch overview panel
- add database settings submenus for `general`, `backup`, and `restore`
- add database rename in general settings and keep delete database there

## Validation
- bun run typecheck
- bun run lint
