### PR TITLE
fix(deploy): fail stuck deployments after timeout

### DIFF
--- a/apps/app/src/instrumentation.ts
+++ b/apps/app/src/instrumentation.ts
@@ -22,6 +22,18 @@ export async function register() {
     const { persistUpdateResult } = await import("./lib/updater");
     await persistUpdateResult();
 
+    const { failStaleInProgressDeployments } = await import(
+      "./lib/deployment-runtime"
+    );
+    const staleDeployments = await failStaleInProgressDeployments();
+    if (staleDeployments > 0) {
+      console.log(
+        `[startup] deployments: failed ${staleDeployments} stale in-progress deployment(s)`,
+      );
+    } else {
+      console.log("[startup] deployments: no stale in-progress deployments");
+    }
+
     const { startMetricsCollector } = await import("./lib/metrics-collector");
     startMetricsCollector();
     console.log("[startup] metrics collector: started");

--- a/apps/app/src/lib/deployer.integration.test.ts
+++ b/apps/app/src/lib/deployer.integration.test.ts
@@ -365,10 +365,7 @@ describe("zero-downtime deploy", () => {
       });
 
       const deploy2Id = await deployService(ZD_SERVICE_ID);
-      const status2 = await waitForDeploymentStatus(deploy2Id, [
-        "running",
-        "failed",
-      ]);
+      const status2 = await waitForDeploymentStatus(deploy2Id, ["failed"]);
       expect(status2).toBe("failed");
 
       const service = await db

--- a/apps/app/src/lib/deployer.ts
+++ b/apps/app/src/lib/deployer.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from "node:child_process";
+import { exec } from "node:child_process";
 import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { promisify } from "node:util";
@@ -8,6 +8,11 @@ import { emitBuildLogChunk } from "./build-log-stream";
 import { decrypt } from "./crypto";
 import { db } from "./db";
 import type { Environments, Projects, Registries, Services } from "./db-types";
+import {
+  createRemainingDeployTimeoutMsGetter,
+  getDeployTimeoutError,
+  getDeployTimeoutMs,
+} from "./deployment-timeout";
 import {
   type BuildResult,
   buildImage,
@@ -40,6 +45,7 @@ import {
 } from "./github";
 import { detectIcon, detectIconFromImage } from "./icon-detector";
 import { newDeploymentId, newReplicaId } from "./id";
+import { runCommand } from "./process-runner";
 import { shellEscape } from "./shell-escape";
 import { slugify } from "./slugify";
 import { generateSelfSignedCert, getSSLPaths, sslCertsExist } from "./ssl";
@@ -630,6 +636,7 @@ interface StartReplicasOptions {
   memoryLimit?: string;
   cpuLimit?: number;
   shutdownTimeout?: number;
+  getRemainingTimeoutMs: () => number;
 }
 
 async function startReplicas(
@@ -700,6 +707,7 @@ async function startReplicas(
             memoryLimit: opts.memoryLimit,
             cpuLimit: opts.cpuLimit,
             shutdownTimeout: opts.shutdownTimeout,
+            timeoutMs: opts.getRemainingTimeoutMs(),
           },
           async ({ port, attempt, reason }) => {
             if (reason === "port-conflict") {
@@ -771,8 +779,18 @@ async function healthCheckReplicas(
   replicaCount: number,
   healthCheckPath: string | null,
   healthCheckTimeout: number | null,
+  getRemainingTimeoutMs: () => number,
 ): Promise<void> {
   const healthCheckType = healthCheckPath ? `HTTP ${healthCheckPath}` : "TCP";
+  const configuredTimeoutSeconds = healthCheckTimeout ?? 60;
+  const timeoutSeconds = Math.max(
+    1,
+    Math.min(
+      configuredTimeoutSeconds,
+      Math.floor(getRemainingTimeoutMs() / 1000),
+    ),
+  );
+  const hitDeployTimeout = timeoutSeconds < configuredTimeoutSeconds;
 
   if (replicaCount > 1) {
     await appendLog(
@@ -792,7 +810,7 @@ async function healthCheckReplicas(
         containerId: r.containerId,
         port: r.hostPort,
         path: healthCheckPath,
-        timeoutSeconds: healthCheckTimeout ?? 60,
+        timeoutSeconds,
       });
       return { ...r, isHealthy };
     }),
@@ -800,6 +818,10 @@ async function healthCheckReplicas(
 
   const failedReplicas = healthResults.filter((r) => !r.isHealthy);
   if (failedReplicas.length > 0) {
+    if (hitDeployTimeout) {
+      throw new Error(getDeployTimeoutError());
+    }
+
     for (const failed of failedReplicas) {
       const containerStatus = await getContainerStatus(failed.containerId);
       await appendLog(
@@ -1092,6 +1114,12 @@ async function runServiceDeployment(
   options?: DeployOptions,
 ) {
   let currentCommitSha = options?.commitSha || "HEAD";
+  const deployStartedAt = Date.now();
+  const deployTimeoutMs = getDeployTimeoutMs();
+  const getRemainingTimeoutMs = createRemainingDeployTimeoutMsGetter(
+    deployStartedAt,
+    deployTimeoutMs,
+  );
   const containerName = sanitizeDockerName(
     `frost-${service.id}-${deploymentId}`,
   );
@@ -1141,6 +1169,7 @@ async function runServiceDeployment(
           registryUrl,
           registry.username,
           password,
+          getRemainingTimeoutMs(),
         );
         if (!loginResult.success) {
           throw new Error(`Registry login failed: ${loginResult.error}`);
@@ -1149,7 +1178,9 @@ async function runServiceDeployment(
 
       await appendLog(deploymentId, `Pulling image ${imageName}...\n`);
 
-      const pullResult = await pullImage(imageName);
+      const pullResult = await pullImage(imageName, {
+        timeoutMs: getRemainingTimeoutMs(),
+      });
       await appendLog(deploymentId, pullResult.log);
 
       if (!pullResult.success) {
@@ -1229,14 +1260,15 @@ async function runServiceDeployment(
       }
 
       const cloneLogAppender = createLogChunkAppender(deploymentId);
-      let cloneResult: { output: string; code: number | null } | null = null;
+      let cloneResult: {
+        output: string;
+        code: number | null;
+        error?: string;
+      } | null = null;
       try {
-        cloneResult = await new Promise<{
-          output: string;
-          code: number | null;
-        }>((resolve, reject) => {
-          let output = "";
-          const proc = spawn("git", [
+        const result = await runCommand({
+          command: "git",
+          args: [
             "clone",
             "--depth",
             "1",
@@ -1244,22 +1276,17 @@ async function runServiceDeployment(
             branch,
             cloneUrl,
             repoPath,
-          ]);
-          proc.stdout.on("data", (data) => {
-            const chunk = data.toString();
-            output += chunk;
+          ],
+          timeoutMs: getRemainingTimeoutMs(),
+          onData(chunk) {
             cloneLogAppender.append(chunk);
-          });
-          proc.stderr.on("data", (data) => {
-            const chunk = data.toString();
-            output += chunk;
-            cloneLogAppender.append(chunk);
-          });
-          proc.on("close", (code) => {
-            resolve({ output, code });
-          });
-          proc.on("error", reject);
+          },
         });
+        cloneResult = {
+          output: result.output,
+          code: result.code,
+          error: result.error,
+        };
       } finally {
         await cloneLogAppender.flush();
       }
@@ -1273,7 +1300,8 @@ async function runServiceDeployment(
       }
       if (cloneResult.code !== 0) {
         throw new Error(
-          cloneResult.output ||
+          cloneResult.error ||
+            cloneResult.output ||
             `git clone exited with code ${cloneResult.code}`,
         );
       }
@@ -1343,6 +1371,7 @@ async function runServiceDeployment(
           buildContext: service.buildContext ?? undefined,
           envVars,
           labels: baseLabels,
+          timeoutMs: getRemainingTimeoutMs(),
           onData(chunk) {
             buildLogAppender.append(chunk);
           },
@@ -1486,6 +1515,7 @@ async function runServiceDeployment(
       memoryLimit: effectiveService.memoryLimit ?? undefined,
       cpuLimit: effectiveService.cpuLimit ?? undefined,
       shutdownTimeout: service.shutdownTimeout ?? undefined,
+      getRemainingTimeoutMs,
     });
 
     await healthCheckReplicas(
@@ -1494,6 +1524,7 @@ async function runServiceDeployment(
       replicaCount,
       effectiveService.healthCheckPath,
       effectiveService.healthCheckTimeout,
+      getRemainingTimeoutMs,
     );
 
     const firstReplica = startedReplicas[0];
@@ -1720,6 +1751,12 @@ async function runRollbackDeployment(
   environment: Selectable<Environments>,
   project: Selectable<Projects>,
 ) {
+  const rollbackStartedAt = Date.now();
+  const rollbackTimeoutMs = getDeployTimeoutMs();
+  const getRemainingTimeoutMs = createRemainingDeployTimeoutMsGetter(
+    rollbackStartedAt,
+    rollbackTimeoutMs,
+  );
   const containerName = sanitizeDockerName(
     `frost-${service.id}-${deploymentId}`,
   );
@@ -1811,6 +1848,7 @@ async function runRollbackDeployment(
       memoryLimit: service.memoryLimit ?? undefined,
       cpuLimit: service.cpuLimit ?? undefined,
       shutdownTimeout: service.shutdownTimeout ?? undefined,
+      getRemainingTimeoutMs,
     });
 
     await healthCheckReplicas(
@@ -1819,6 +1857,7 @@ async function runRollbackDeployment(
       replicaCount,
       sourceDeployment.healthCheckPath,
       sourceDeployment.healthCheckTimeout,
+      getRemainingTimeoutMs,
     );
 
     const firstReplica = startedReplicas[0];

--- a/apps/app/src/lib/deployment-runtime.test.ts
+++ b/apps/app/src/lib/deployment-runtime.test.ts
@@ -1,0 +1,126 @@
+import { describe, expect, test } from "bun:test";
+import { nanoid } from "nanoid";
+import { db } from "./db";
+import { reconcileDeploymentRuntimeStatus } from "./deployment-runtime";
+import { getDeployTimeoutError } from "./deployment-timeout";
+import { runMigrations } from "./migrate";
+
+runMigrations();
+
+interface TestFixture {
+  projectId: string;
+  environmentId: string;
+  serviceId: string;
+}
+
+async function createFixture(): Promise<TestFixture> {
+  const suffix = nanoid(8);
+  const projectId = `proj-deploy-runtime-${suffix}`;
+  const environmentId = `env-deploy-runtime-${suffix}`;
+  const serviceId = `svc-deploy-runtime-${suffix}`;
+  const now = Date.now();
+
+  await db
+    .insertInto("projects")
+    .values({
+      id: projectId,
+      name: `deploy-runtime-${suffix}`,
+      envVars: "[]",
+      createdAt: now,
+    })
+    .execute();
+
+  await db
+    .insertInto("environments")
+    .values({
+      id: environmentId,
+      projectId,
+      name: "production",
+      type: "production",
+      isEphemeral: false,
+      createdAt: now,
+    })
+    .execute();
+
+  await db
+    .insertInto("services")
+    .values({
+      id: serviceId,
+      environmentId,
+      name: `deploy-runtime-${suffix}`,
+      deployType: "image",
+      imageUrl: "nginx:alpine",
+      envVars: "[]",
+      createdAt: now,
+    })
+    .execute();
+
+  return { projectId, environmentId, serviceId };
+}
+
+async function cleanupFixture(fixture: TestFixture): Promise<void> {
+  await db
+    .updateTable("services")
+    .set({ currentDeploymentId: null })
+    .where("id", "=", fixture.serviceId)
+    .execute();
+
+  await db
+    .deleteFrom("deployments")
+    .where("serviceId", "=", fixture.serviceId)
+    .execute();
+
+  await db.deleteFrom("services").where("id", "=", fixture.serviceId).execute();
+  await db
+    .deleteFrom("environments")
+    .where("id", "=", fixture.environmentId)
+    .execute();
+  await db.deleteFrom("projects").where("id", "=", fixture.projectId).execute();
+}
+
+describe("reconcileDeploymentRuntimeStatus", function describeRuntimeStatus() {
+  test("fails stale in-progress deployments", async function testStaleDeploy() {
+    const fixture = await createFixture();
+
+    try {
+      const deploymentId = `dep-deploy-runtime-${nanoid(8)}`;
+      await db
+        .insertInto("deployments")
+        .values({
+          id: deploymentId,
+          serviceId: fixture.serviceId,
+          environmentId: fixture.environmentId,
+          commitSha: "HEAD",
+          status: "building",
+          createdAt: Date.now() - 31 * 60 * 1000,
+        })
+        .execute();
+
+      const deployment = await db
+        .selectFrom("deployments")
+        .selectAll()
+        .where("id", "=", deploymentId)
+        .executeTakeFirst();
+
+      const reconciled = await reconcileDeploymentRuntimeStatus(
+        deployment ?? null,
+      );
+
+      expect(reconciled?.status).toBe("failed");
+      expect(reconciled?.errorMessage).toBe(getDeployTimeoutError());
+      expect(typeof reconciled?.finishedAt).toBe("number");
+
+      const persisted = await db
+        .selectFrom("deployments")
+        .select(["status", "errorMessage", "finishedAt"])
+        .where("id", "=", deploymentId)
+        .executeTakeFirst();
+
+      expect(persisted?.status).toBe("failed");
+      expect(persisted?.errorMessage).toBe(getDeployTimeoutError());
+      expect(typeof persisted?.finishedAt).toBe("number");
+    } finally {
+      await cleanupFixture(fixture);
+    }
+  });
+});

--- a/apps/app/src/lib/deployment-runtime.ts
+++ b/apps/app/src/lib/deployment-runtime.ts
@@ -1,8 +1,20 @@
 import type { Selectable } from "kysely";
 import { db } from "./db";
 import type { Deployments, Services } from "./db-types";
-import { getContainerStatus } from "./docker";
+import {
+  getDeployTimeoutError,
+  getDeployTimeoutMs,
+  hasDeploymentTimedOut,
+} from "./deployment-timeout";
+import { getContainerStatus, stopContainer } from "./docker";
 
+const IN_PROGRESS_DEPLOYMENT_STATUS_LIST = [
+  "pending",
+  "cloning",
+  "pulling",
+  "building",
+  "deploying",
+] as const;
 const LIVE_CONTAINER_STATUSES = new Set(["running", "restarting", "paused"]);
 
 function isContainerLive(status: string): boolean {
@@ -23,6 +35,107 @@ function isDeployment(
   deployment: Selectable<Deployments> | null,
 ): deployment is Selectable<Deployments> {
   return deployment !== null;
+}
+
+function canFailTimedOutDeployment(
+  deployment: Selectable<Deployments> | null,
+): deployment is Selectable<Deployments> {
+  return deployment !== null && isInProgressDeploymentStatus(deployment.status);
+}
+
+function isInProgressDeploymentStatus(
+  status: Selectable<Deployments>["status"],
+): status is (typeof IN_PROGRESS_DEPLOYMENT_STATUS_LIST)[number] {
+  return (IN_PROGRESS_DEPLOYMENT_STATUS_LIST as readonly string[]).includes(
+    status,
+  );
+}
+
+async function stopDeploymentContainers(deploymentId: string): Promise<void> {
+  const deployment = await db
+    .selectFrom("deployments")
+    .select("containerId")
+    .where("id", "=", deploymentId)
+    .executeTakeFirst();
+
+  const replicas = await db
+    .selectFrom("replicas")
+    .select("containerId")
+    .where("deploymentId", "=", deploymentId)
+    .where("containerId", "is not", null)
+    .execute();
+
+  const containerIds = new Set<string>();
+  if (deployment?.containerId) {
+    containerIds.add(deployment.containerId);
+  }
+
+  for (const replica of replicas) {
+    if (replica.containerId) {
+      containerIds.add(replica.containerId);
+    }
+  }
+
+  for (const containerId of containerIds) {
+    await stopContainer(containerId);
+  }
+}
+
+async function markDeploymentTimedOut(
+  deployment: Selectable<Deployments>,
+): Promise<Selectable<Deployments>> {
+  const errorMessage = getDeployTimeoutError();
+  const finishedAt = Date.now();
+
+  await stopDeploymentContainers(deployment.id);
+
+  await db
+    .updateTable("replicas")
+    .set({ status: "failed" })
+    .where("deploymentId", "=", deployment.id)
+    .execute();
+
+  await db.transaction().execute(async function onTimeout(trx) {
+    await trx
+      .updateTable("deployments")
+      .set({
+        status: "failed",
+        errorMessage,
+        finishedAt,
+        rollbackEligible: false,
+      })
+      .where("id", "=", deployment.id)
+      .execute();
+
+    await trx
+      .updateTable("services")
+      .set({ currentDeploymentId: null })
+      .where("id", "=", deployment.serviceId)
+      .where("currentDeploymentId", "=", deployment.id)
+      .execute();
+  });
+
+  return {
+    ...deployment,
+    status: "failed",
+    errorMessage,
+    finishedAt,
+    rollbackEligible: false,
+  };
+}
+
+async function reconcileTimedOutDeployment(
+  deployment: Selectable<Deployments> | null,
+): Promise<Selectable<Deployments> | null> {
+  if (!canFailTimedOutDeployment(deployment)) {
+    return deployment;
+  }
+
+  if (!hasDeploymentTimedOut(deployment.createdAt)) {
+    return deployment;
+  }
+
+  return markDeploymentTimedOut(deployment);
 }
 
 async function hasLiveReplicaContainer(
@@ -78,24 +191,30 @@ async function markDeploymentStopped(
 export async function reconcileDeploymentRuntimeStatus(
   deployment: Selectable<Deployments> | null,
 ): Promise<Selectable<Deployments> | null> {
-  if (!canReconcileDeployment(deployment)) {
-    return deployment;
+  const timedOutDeployment = await reconcileTimedOutDeployment(deployment);
+
+  if (!canReconcileDeployment(timedOutDeployment)) {
+    return timedOutDeployment;
   }
 
-  const liveReplicaContainer = await hasLiveReplicaContainer(deployment.id);
+  const liveReplicaContainer = await hasLiveReplicaContainer(
+    timedOutDeployment.id,
+  );
   if (liveReplicaContainer === true) {
-    return deployment;
+    return timedOutDeployment;
   }
   if (liveReplicaContainer === false) {
-    return markDeploymentStopped(deployment);
+    return markDeploymentStopped(timedOutDeployment);
   }
 
-  const containerStatus = await getContainerStatus(deployment.containerId);
+  const containerStatus = await getContainerStatus(
+    timedOutDeployment.containerId,
+  );
   if (containerStatus === "unknown" || isContainerLive(containerStatus)) {
-    return deployment;
+    return timedOutDeployment;
   }
 
-  return markDeploymentStopped(deployment);
+  return markDeploymentStopped(timedOutDeployment);
 }
 
 export async function getLatestDeploymentWithRuntimeStatus(
@@ -145,4 +264,25 @@ export async function reconcileDeploymentsRuntimeStatus(
     ),
   );
   return reconciled.filter(isDeployment);
+}
+
+export async function failStaleInProgressDeployments(): Promise<number> {
+  const cutoff = Date.now() - getDeployTimeoutMs();
+  const deployments = await db
+    .selectFrom("deployments")
+    .selectAll()
+    .where("status", "in", [...IN_PROGRESS_DEPLOYMENT_STATUS_LIST])
+    .where("createdAt", "<=", cutoff)
+    .execute();
+
+  let failedCount = 0;
+
+  for (const deployment of deployments) {
+    const reconciled = await reconcileTimedOutDeployment(deployment);
+    if (reconciled?.status === "failed") {
+      failedCount += 1;
+    }
+  }
+
+  return failedCount;
 }

--- a/apps/app/src/lib/deployment-timeout.ts
+++ b/apps/app/src/lib/deployment-timeout.ts
@@ -1,0 +1,78 @@
+const DEFAULT_DEPLOY_TIMEOUT_MS = 30 * 60 * 1000;
+const MIN_DEPLOY_TIMEOUT_MS = 1000;
+
+function parseTimeoutEnv(
+  name: string,
+  fallback: number,
+  minimum: number,
+): number {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+
+  const value = Number.parseInt(raw, 10);
+  if (!Number.isFinite(value) || Number.isNaN(value)) {
+    return fallback;
+  }
+
+  return Math.max(value, minimum);
+}
+
+function formatDeployTimeout(timeoutMs: number): string {
+  if (timeoutMs % (60 * 1000) === 0) {
+    const minutes = timeoutMs / (60 * 1000);
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+
+  const seconds = Math.ceil(timeoutMs / 1000);
+  return `${seconds} second${seconds === 1 ? "" : "s"}`;
+}
+
+export function getDeployTimeoutMs(): number {
+  return parseTimeoutEnv(
+    "FROST_DEPLOY_TIMEOUT_MS",
+    DEFAULT_DEPLOY_TIMEOUT_MS,
+    MIN_DEPLOY_TIMEOUT_MS,
+  );
+}
+
+export function getDeployTimeoutError(
+  timeoutMs: number = getDeployTimeoutMs(),
+): string {
+  return `Deployment exceeded max time of ${formatDeployTimeout(timeoutMs)}`;
+}
+
+export function getRemainingDeployTimeoutMs(
+  startedAt: number,
+  timeoutMs: number = getDeployTimeoutMs(),
+): number {
+  return timeoutMs - (Date.now() - startedAt);
+}
+
+export function getRequiredRemainingDeployTimeoutMs(
+  startedAt: number,
+  timeoutMs: number = getDeployTimeoutMs(),
+): number {
+  const remainingMs = getRemainingDeployTimeoutMs(startedAt, timeoutMs);
+  if (remainingMs <= 0) {
+    throw new Error(getDeployTimeoutError(timeoutMs));
+  }
+  return remainingMs;
+}
+
+export function createRemainingDeployTimeoutMsGetter(
+  startedAt: number,
+  timeoutMs: number = getDeployTimeoutMs(),
+): () => number {
+  return function getRemainingTimeoutMs(): number {
+    return getRequiredRemainingDeployTimeoutMs(startedAt, timeoutMs);
+  };
+}
+
+export function hasDeploymentTimedOut(
+  createdAt: number,
+  timeoutMs: number = getDeployTimeoutMs(),
+): boolean {
+  return Date.now() - createdAt >= timeoutMs;
+}

--- a/apps/app/src/lib/docker.ts
+++ b/apps/app/src/lib/docker.ts
@@ -4,6 +4,7 @@ import { join, relative } from "node:path";
 import { promisify } from "node:util";
 
 import { db } from "./db";
+import { runCommand } from "./process-runner";
 import { buildDockerRunArgs, shellEscape } from "./shell-escape";
 
 const execAsync = promisify(exec);
@@ -31,6 +32,7 @@ export interface BuildImageOptions {
   envVars?: Record<string, string>;
   labels?: Record<string, string>;
   onData?: (chunk: string) => void;
+  timeoutMs?: number;
 }
 
 export async function buildImage(
@@ -57,66 +59,58 @@ export async function buildImage(
     envVars,
     labels,
     onData,
+    timeoutMs,
   } = options;
 
   if (await imageExists(imageName)) {
     await removeImage(imageName);
   }
 
-  return new Promise((resolve) => {
-    let log = "";
-    const contextPath = buildContext ? join(repoPath, buildContext) : repoPath;
-    const resolvedDockerfile = buildContext
-      ? relative(contextPath, join(repoPath, dockerfilePath))
-      : dockerfilePath;
-    const args = ["build", "-t", imageName, "-f", resolvedDockerfile];
-    if (envVars) {
-      for (const [key, value] of Object.entries(envVars)) {
-        args.push("--build-arg", `${key}=${value}`);
-      }
+  const contextPath = buildContext ? join(repoPath, buildContext) : repoPath;
+  const resolvedDockerfile = buildContext
+    ? relative(contextPath, join(repoPath, dockerfilePath))
+    : dockerfilePath;
+  const args = ["build", "-t", imageName, "-f", resolvedDockerfile];
+  if (envVars) {
+    for (const [key, value] of Object.entries(envVars)) {
+      args.push("--build-arg", `${key}=${value}`);
     }
-    if (labels) {
-      for (const [key, value] of Object.entries(labels)) {
-        args.push("--label", `${key}=${value}`);
-      }
+  }
+  if (labels) {
+    for (const [key, value] of Object.entries(labels)) {
+      args.push("--label", `${key}=${value}`);
     }
-    args.push(".");
-    const proc = spawn("docker", args, {
-      cwd: contextPath,
-    });
+  }
+  args.push(".");
 
-    proc.stdout.on("data", (data) => {
-      const chunk = data.toString();
-      log += chunk;
-      onData?.(chunk);
-    });
-
-    proc.stderr.on("data", (data) => {
-      const chunk = data.toString();
-      log += chunk;
-      onData?.(chunk);
-    });
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve({ success: true, imageName, log });
-      } else {
-        resolve({
-          success: false,
-          imageName,
-          log,
-          error: `Build exited with code ${code}`,
-        });
-      }
-    });
-
-    proc.on("error", (err) => {
-      resolve({ success: false, imageName, log, error: err.message });
-    });
+  const result = await runCommand({
+    command: "docker",
+    args,
+    cwd: contextPath,
+    timeoutMs,
+    onData,
   });
+
+  if (result.code === 0 && !result.timedOut) {
+    return { success: true, imageName, log: result.output };
+  }
+
+  return {
+    success: false,
+    imageName,
+    log: result.output,
+    error: result.error || `Build exited with code ${result.code}`,
+  };
 }
 
-export async function pullImage(imageName: string): Promise<BuildResult> {
+export interface PullImageOptions {
+  timeoutMs?: number;
+}
+
+export async function pullImage(
+  imageName: string,
+  options: PullImageOptions = {},
+): Promise<BuildResult> {
   const retryCount = parseEnvInt("FROST_IMAGE_PULL_RETRIES", 3, 1);
   const backoffMs = parseEnvInt("FROST_IMAGE_PULL_BACKOFF_MS", 2000, 0);
   const maxBackoffMs = parseEnvInt(
@@ -129,13 +123,29 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
   let combinedLog = "";
   let lastError = "Pull failed";
   let lastFailureClass = "unknown";
+  const startedAt = Date.now();
 
   for (let attempt = 1; attempt <= retryCount; attempt++) {
+    const remainingTimeoutMs = getRemainingTimeout(
+      options.timeoutMs,
+      startedAt,
+    );
+    if (remainingTimeoutMs !== undefined && remainingTimeoutMs <= 0) {
+      lastError = `Pull timed out after ${options.timeoutMs}ms`;
+      lastFailureClass = "infra/timeout";
+      combinedLog += `[pull-attempt ${attempt}/${retryCount}] failed class=${lastFailureClass} error=${lastError}\n`;
+      break;
+    }
+
     const pullCmd = hostPlatform
       ? `docker pull --platform ${hostPlatform} ${imageName}`
       : `docker pull ${imageName}`;
     combinedLog += `\n[pull-attempt ${attempt}/${retryCount}] ${pullCmd}\n`;
-    const attemptResult = await runDockerPull(imageName, hostPlatform);
+    const attemptResult = await runDockerPull(
+      imageName,
+      hostPlatform,
+      remainingTimeoutMs,
+    );
     const failureClass = classifyPullFailure(
       attemptResult.log,
       attemptResult.error,
@@ -203,41 +213,15 @@ export async function pullImage(imageName: string): Promise<BuildResult> {
 function runDockerPull(
   imageName: string,
   platform?: string | null,
+  timeoutMs?: number,
 ): Promise<{ success: boolean; log: string; error?: string; code?: number }> {
-  return new Promise((resolve) => {
-    let log = "";
-    const args = ["pull"];
-    if (platform) {
-      args.push("--platform", platform);
-    }
-    args.push(imageName);
-    const proc = spawn("docker", args);
+  const args = ["pull"];
+  if (platform) {
+    args.push("--platform", platform);
+  }
+  args.push(imageName);
 
-    proc.stdout.on("data", (data) => {
-      log += data.toString();
-    });
-
-    proc.stderr.on("data", (data) => {
-      log += data.toString();
-    });
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve({ success: true, log });
-      } else {
-        resolve({
-          success: false,
-          log,
-          error: `Pull exited with code ${code}`,
-          code: code ?? undefined,
-        });
-      }
-    });
-
-    proc.on("error", (err) => {
-      resolve({ success: false, log, error: err.message });
-    });
-  });
+  return runDockerCommand(args, timeoutMs);
 }
 
 export function classifyPullFailure(log: string, error?: string): string {
@@ -377,6 +361,39 @@ function sleep(ms: number): Promise<void> {
   });
 }
 
+function getRemainingTimeout(
+  timeoutMs: number | undefined,
+  startedAt: number,
+): number | undefined {
+  if (!timeoutMs) {
+    return undefined;
+  }
+
+  return timeoutMs - (Date.now() - startedAt);
+}
+
+async function runDockerCommand(
+  args: string[],
+  timeoutMs?: number,
+): Promise<{ success: boolean; log: string; error?: string; code?: number }> {
+  const result = await runCommand({
+    command: "docker",
+    args,
+    timeoutMs,
+  });
+
+  if (result.code === 0 && !result.timedOut) {
+    return { success: true, log: result.output };
+  }
+
+  return {
+    success: false,
+    log: result.output,
+    error: result.error || `Command exited with code ${result.code}`,
+    code: result.code ?? undefined,
+  };
+}
+
 export function getRegistryUrl(type: string, customUrl: string | null): string {
   if (type === "ghcr") return "ghcr.io";
   if (type === "dockerhub") return "docker.io";
@@ -393,40 +410,24 @@ export async function dockerLogin(
   registryUrl: string,
   username: string,
   password: string,
+  timeoutMs?: number,
 ): Promise<DockerLoginResult> {
-  return new Promise((resolve) => {
-    const proc = spawn("docker", [
-      "login",
-      "-u",
-      username,
-      "--password-stdin",
-      registryUrl,
-    ]);
-
-    let stderr = "";
-
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-
-    proc.stdin.write(password);
-    proc.stdin.end();
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve({ success: true });
-      } else {
-        resolve({
-          success: false,
-          error: stderr || `Login failed with code ${code}`,
-        });
-      }
-    });
-
-    proc.on("error", (err) => {
-      resolve({ success: false, error: err.message });
-    });
+  const result = await runCommand({
+    command: "docker",
+    args: ["login", "-u", username, "--password-stdin", registryUrl],
+    stdin: password,
+    timeoutMs,
   });
+
+  if (result.code === 0 && !result.timedOut) {
+    return { success: true };
+  }
+
+  return {
+    success: false,
+    error:
+      result.error || result.stderr || `Login failed with code ${result.code}`,
+  };
 }
 
 export interface VolumeMount {
@@ -455,40 +456,31 @@ export interface RunContainerOptions {
   memoryLimit?: string;
   cpuLimit?: number;
   shutdownTimeout?: number;
+  timeoutMs?: number;
 }
 
 export async function runContainer(
   options: RunContainerOptions,
 ): Promise<RunResult> {
   const args = buildDockerRunArgs(options);
-  return new Promise((resolve) => {
-    let stdout = "";
-    let stderr = "";
-    const proc = spawn("docker", args);
-
-    proc.stdout.on("data", (data) => {
-      stdout += data.toString();
-    });
-    proc.stderr.on("data", (data) => {
-      stderr += data.toString();
-    });
-
-    proc.on("close", (code) => {
-      if (code === 0) {
-        resolve({ success: true, containerId: stdout.trim() });
-      } else {
-        resolve({
-          success: false,
-          containerId: "",
-          error: stderr || `docker run exited with code ${code}`,
-        });
-      }
-    });
-
-    proc.on("error", (err) => {
-      resolve({ success: false, containerId: "", error: err.message });
-    });
+  const result = await runCommand({
+    command: "docker",
+    args,
+    timeoutMs: options.timeoutMs,
   });
+
+  if (result.code === 0 && !result.timedOut) {
+    return { success: true, containerId: result.stdout.trim() };
+  }
+
+  return {
+    success: false,
+    containerId: "",
+    error:
+      result.error ||
+      result.stderr ||
+      `docker run exited with code ${result.code}`,
+  };
 }
 
 export async function stopContainer(name: string): Promise<void> {
@@ -824,7 +816,7 @@ export function streamContainerLogs(
     }
   });
 
-  proc.on("error", (err) => {
+  proc.on("error", (err: Error) => {
     onError(err);
   });
 

--- a/apps/app/src/lib/process-runner.test.ts
+++ b/apps/app/src/lib/process-runner.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+import { runCommand } from "./process-runner";
+
+describe("runCommand", function describeRunCommand() {
+  test("times out a long-running process", async function testTimeout() {
+    const result = await runCommand({
+      command: process.execPath,
+      args: ["-e", "setTimeout(function holdOpen() {}, 5000)"],
+      timeoutMs: 100,
+    });
+
+    expect(result.timedOut).toBe(true);
+    expect(result.error).toContain("timed out");
+  });
+});

--- a/apps/app/src/lib/process-runner.ts
+++ b/apps/app/src/lib/process-runner.ts
@@ -1,0 +1,123 @@
+import { spawn } from "node:child_process";
+
+const FORCE_KILL_DELAY_MS = 5000;
+
+export interface RunCommandOptions {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  stdin?: string;
+  timeoutMs?: number;
+  onData?: (chunk: string) => void;
+}
+
+export interface RunCommandResult {
+  code: number | null;
+  signal: NodeJS.Signals | null;
+  stdout: string;
+  stderr: string;
+  output: string;
+  timedOut: boolean;
+  error?: string;
+}
+
+function clearTimer(timer: ReturnType<typeof setTimeout> | null): void {
+  if (timer) {
+    clearTimeout(timer);
+  }
+}
+
+function stopProcess(
+  proc: ReturnType<typeof spawn>,
+  signal: NodeJS.Signals,
+): void {
+  try {
+    proc.kill(signal);
+  } catch {}
+}
+
+export function runCommand(
+  options: RunCommandOptions,
+): Promise<RunCommandResult> {
+  return new Promise(function onCreate(resolve) {
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    let settled = false;
+    let timeoutTimer: ReturnType<typeof setTimeout> | null = null;
+    let forceKillTimer: ReturnType<typeof setTimeout> | null = null;
+
+    const proc = spawn(options.command, options.args, {
+      cwd: options.cwd,
+      env: options.env,
+    });
+
+    function finish(result: RunCommandResult): void {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimer(timeoutTimer);
+      clearTimer(forceKillTimer);
+      resolve(result);
+    }
+
+    if (options.timeoutMs && options.timeoutMs > 0) {
+      timeoutTimer = setTimeout(function onTimeout() {
+        timedOut = true;
+        stopProcess(proc, "SIGTERM");
+        forceKillTimer = setTimeout(function onForceKill() {
+          stopProcess(proc, "SIGKILL");
+        }, FORCE_KILL_DELAY_MS);
+      }, options.timeoutMs);
+    }
+
+    proc.stdout.on("data", function onStdout(data) {
+      const chunk = data.toString();
+      stdout += chunk;
+      options.onData?.(chunk);
+    });
+
+    proc.stderr.on("data", function onStderr(data) {
+      const chunk = data.toString();
+      stderr += chunk;
+      options.onData?.(chunk);
+    });
+
+    proc.on("close", function onClose(code, signal) {
+      const output = stdout + stderr;
+      finish({
+        code,
+        signal,
+        stdout,
+        stderr,
+        output,
+        timedOut,
+        error:
+          timedOut && options.timeoutMs
+            ? `Command timed out after ${options.timeoutMs}ms`
+            : undefined,
+      });
+    });
+
+    proc.on("error", function onError(err) {
+      const output = stdout + stderr;
+      finish({
+        code: null,
+        signal: null,
+        stdout,
+        stderr,
+        output,
+        timedOut,
+        error: err.message,
+      });
+    });
+
+    if (options.stdin !== undefined) {
+      proc.stdin.on("error", function ignoreError() {});
+      proc.stdin.write(options.stdin);
+      proc.stdin.end();
+    }
+  });
+}

--- a/apps/app/src/server/deployments.ts
+++ b/apps/app/src/server/deployments.ts
@@ -1,6 +1,10 @@
 import { ORPCError } from "@orpc/server";
 import { db } from "@/lib/db";
 import { rollbackDeployment } from "@/lib/deployer";
+import {
+  reconcileDeploymentRuntimeStatus,
+  reconcileDeploymentsRuntimeStatus,
+} from "@/lib/deployment-runtime";
 import { imageExists } from "@/lib/docker";
 import { assertDemoWriteAllowed } from "./demo-guards";
 import { os } from "./orpc";
@@ -17,18 +21,27 @@ export const deployments = {
       throw new ORPCError("NOT_FOUND", { message: "Deployment not found" });
     }
 
-    return deployment;
+    const reconciled = await reconcileDeploymentRuntimeStatus(deployment);
+    if (!reconciled) {
+      throw new ORPCError("INTERNAL_SERVER_ERROR", {
+        message: "Failed to load deployment",
+      });
+    }
+
+    return reconciled;
   }),
 
   listByEnvironment: os.deployments.listByEnvironment.handler(
     async ({ input }) => {
-      return db
+      const deployments = await db
         .selectFrom("deployments")
         .selectAll()
         .where("environmentId", "=", input.environmentId)
         .orderBy("createdAt", "desc")
         .limit(50)
         .execute();
+
+      return reconcileDeploymentsRuntimeStatus(deployments);
     },
   ),
 


### PR DESCRIPTION
## Summary
- add a 30 minute deploy timeout guard for long-running deploy steps
- fail stale in-progress deployments on startup and when reading deployment state
- add focused tests for command timeout and stale deployment cleanup

## Checks
- bun run typecheck
- bun run lint
- bun test src/lib/process-runner.test.ts src/lib/deployment-runtime.test.ts
