### PR TITLE
feat(db): add postgres import wizard

### DIFF
--- a/apps/app/schema/018-database-import-jobs.sql
+++ b/apps/app/schema/018-database-import-jobs.sql
@@ -1,0 +1,41 @@
+CREATE TABLE database_import_jobs (
+  id TEXT PRIMARY KEY,
+  project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+  database_id TEXT REFERENCES databases(id) ON DELETE SET NULL,
+  target_name TEXT NOT NULL,
+  engine TEXT NOT NULL CHECK (engine IN ('postgres')),
+  strategy TEXT NOT NULL DEFAULT 'dump-restore' CHECK (strategy IN ('dump-restore', 'logical-replication')),
+  source_url_encrypted TEXT,
+  source_host TEXT NOT NULL,
+  source_port INTEGER NOT NULL,
+  source_database TEXT NOT NULL,
+  source_username TEXT NOT NULL,
+  source_ssl_mode TEXT NOT NULL,
+  stage TEXT NOT NULL CHECK (
+    stage IN (
+      'source',
+      'preflight',
+      'target',
+      'importing',
+      'imported',
+      'verifying',
+      'ready-for-cutover',
+      'completed',
+      'failed'
+    )
+  ),
+  progress_step TEXT,
+  source_summary_json TEXT NOT NULL DEFAULT '{}',
+  check_results_json TEXT NOT NULL DEFAULT '[]',
+  verify_result_json TEXT NOT NULL DEFAULT '{}',
+  log_text TEXT NOT NULL DEFAULT '',
+  error_message TEXT,
+  cutover_confirmed_at INTEGER,
+  completed_at INTEGER,
+  failed_at INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+
+CREATE INDEX idx_database_import_jobs_project_id ON database_import_jobs(project_id);
+CREATE INDEX idx_database_import_jobs_database_id ON database_import_jobs(database_id);

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/create-service-modal.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/create-service-modal.tsx
@@ -43,6 +43,7 @@ import {
   getDatabaseLogoUrl,
 } from "@/lib/database-logo";
 import { RepoSelector } from "../services/new/_components/repo-selector";
+import { DatabaseImportWizard } from "./database-import-wizard";
 import { type StagedService, StagedServicesList } from "./staged-services-list";
 
 function generateUniqueName(baseName: string, existingNames: string[]): string {
@@ -54,6 +55,7 @@ function generateUniqueName(baseName: string, existingNames: string[]): string {
 }
 
 type Step = "category" | "repo" | "scanning" | "staged" | "image" | "database";
+type DatabaseMode = "menu" | "create" | "import";
 
 interface CreateServiceModalProps {
   projectId: string;
@@ -150,6 +152,7 @@ export function CreateServiceModal({
   const [databaseEngine, setDatabaseEngine] = useState<"postgres" | "mysql">(
     "postgres",
   );
+  const [databaseMode, setDatabaseMode] = useState<DatabaseMode>("menu");
 
   const { data: serviceTemplates } = useQuery({
     queryKey: ["service-templates"],
@@ -167,6 +170,10 @@ export function CreateServiceModal({
   );
   const nextDatabaseName = generateUniqueName(
     databaseEngine,
+    existingDatabaseNames,
+  );
+  const nextImportDatabaseName = generateUniqueName(
+    "postgres",
     existingDatabaseNames,
   );
 
@@ -198,6 +205,7 @@ export function CreateServiceModal({
     setStagedServices([]);
     setSelectedRepo(null);
     setDatabaseEngine("postgres");
+    setDatabaseMode("menu");
   }
 
   function handleOpenChange(isOpen: boolean): void {
@@ -234,6 +242,9 @@ export function CreateServiceModal({
   function handleCategorySelect(id: string): void {
     setSearch("");
     setSelectedIndex(0);
+    if (id === "database") {
+      setDatabaseMode("menu");
+    }
     setStep(id as Step);
   }
 
@@ -394,6 +405,14 @@ export function CreateServiceModal({
       const message =
         err instanceof Error ? err.message : "Failed to create database";
       toast.error(message);
+    }
+  }
+
+  function handleImportFinished(databaseId: string): void {
+    resetState();
+    onOpenChange(false);
+    if (onDatabaseCreated) {
+      onDatabaseCreated(databaseId);
     }
   }
 
@@ -581,11 +600,71 @@ export function CreateServiceModal({
         );
 
       case "database":
+        if (databaseMode === "import") {
+          return (
+            <DatabaseImportWizard
+              projectId={projectId}
+              initialTargetName={nextImportDatabaseName}
+              onBack={function onBack() {
+                setDatabaseMode("menu");
+              }}
+              onFinished={handleImportFinished}
+            />
+          );
+        }
+
+        if (databaseMode === "menu") {
+          return (
+            <div className="space-y-4">
+              <button
+                type="button"
+                onClick={resetState}
+                className="flex items-center gap-1 text-sm text-neutral-400 hover:text-neutral-200"
+              >
+                <ChevronLeft className="h-4 w-4" />
+                Back
+              </button>
+              <div className="space-y-2">
+                <button
+                  type="button"
+                  onClick={function onCreateEmptyClick() {
+                    setDatabaseMode("create");
+                  }}
+                  className="w-full rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-left transition-colors hover:border-neutral-600"
+                >
+                  <p className="text-sm font-medium text-neutral-100">
+                    Create empty database
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-400">
+                    Start with a fresh Postgres or MySQL database
+                  </p>
+                </button>
+                <button
+                  type="button"
+                  onClick={function onImportClick() {
+                    setDatabaseMode("import");
+                  }}
+                  className="w-full rounded-lg border border-neutral-700 bg-neutral-900 p-3 text-left transition-colors hover:border-neutral-600"
+                >
+                  <p className="text-sm font-medium text-neutral-100">
+                    Import existing Postgres
+                  </p>
+                  <p className="mt-1 text-xs text-neutral-400">
+                    Paste a database URL and let Frost move it
+                  </p>
+                </button>
+              </div>
+            </div>
+          );
+        }
+
         return (
           <div className="space-y-4">
             <button
               type="button"
-              onClick={resetState}
+              onClick={function onBack() {
+                setDatabaseMode("menu");
+              }}
               className="flex items-center gap-1 text-sm text-neutral-400 hover:text-neutral-200"
             >
               <ChevronLeft className="h-4 w-4" />
@@ -677,12 +756,30 @@ export function CreateServiceModal({
     }
   }
 
+  function getDialogTitle(): string {
+    if (step === "database") {
+      if (databaseMode === "import") {
+        return "Import Existing Postgres";
+      }
+      if (databaseMode === "menu") {
+        return "Database";
+      }
+    }
+    return STEP_TITLES[step];
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-h-[85vh] overflow-y-auto border-neutral-800 bg-neutral-900 sm:max-w-md">
+      <DialogContent
+        className={`max-h-[85vh] overflow-y-auto border-neutral-800 bg-neutral-900 ${
+          step === "database" && databaseMode === "import"
+            ? "sm:max-w-3xl"
+            : "sm:max-w-md"
+        }`}
+      >
         <DialogHeader>
           <DialogTitle className="text-lg font-medium text-neutral-100">
-            {STEP_TITLES[step]}
+            {getDialogTitle()}
           </DialogTitle>
         </DialogHeader>
         {renderStepContent()}

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { AlertTriangle, CheckCircle2, Circle, Loader2 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -157,6 +157,12 @@ function getStartImportLabel(job: DatabaseImportJob | null): string {
   return "Start import";
 }
 
+function isAtBottom(element: HTMLTextAreaElement): boolean {
+  const distance =
+    element.scrollHeight - element.scrollTop - element.clientHeight;
+  return distance <= 12;
+}
+
 export function DatabaseImportWizard({
   projectId,
   initialTargetName,
@@ -167,6 +173,8 @@ export function DatabaseImportWizard({
   const [sourceUrl, setSourceUrl] = useState("");
   const [currentJob, setCurrentJob] = useState<DatabaseImportJob | null>(null);
   const [externalHost, setExternalHost] = useState("127.0.0.1");
+  const [stickLogToBottom, setStickLogToBottom] = useState(true);
+  const logRef = useRef<HTMLTextAreaElement | null>(null);
 
   const createJobMutation = useCreateDatabaseImportJob(projectId);
   const jobQuery = useDatabaseImportJob(jobId);
@@ -180,6 +188,15 @@ export function DatabaseImportWizard({
       setExternalHost(window.location.hostname);
     }
   }, []);
+
+  const job = jobQuery.data ?? currentJob;
+
+  useEffect(function keepLogAtBottom() {
+    if (!stickLogToBottom || !logRef.current) {
+      return;
+    }
+    logRef.current.scrollTop = logRef.current.scrollHeight;
+  });
 
   async function handlePreflightSubmit(
     event: React.FormEvent<HTMLFormElement>,
@@ -221,9 +238,9 @@ export function DatabaseImportWizard({
     setJobId("");
     setCurrentJob(null);
     setSourceUrl("");
+    setStickLogToBottom(true);
   }
 
-  const job = jobQuery.data ?? currentJob;
   const currentStepIndex = getStepIndex(job);
   const hasBlockedChecks = job
     ? hasBlockedImportChecks(job.checkResults)
@@ -493,8 +510,12 @@ export function DatabaseImportWizard({
                 </div>
               </div>
               <textarea
+                ref={logRef}
                 readOnly
                 value={job.logText}
+                onScroll={function onLogScroll(event) {
+                  setStickLogToBottom(isAtBottom(event.currentTarget));
+                }}
                 className="mt-3 h-48 w-full rounded-lg border border-neutral-800 bg-neutral-950 p-3 font-mono text-[11px] text-neutral-200 outline-none"
               />
               {job.stage === "failed" && canStartImportNow && (

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
@@ -1,0 +1,601 @@
+"use client";
+
+import { AlertTriangle, CheckCircle2, Circle, Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import type { ContractOutputs } from "@/contracts";
+import {
+  useCreateDatabaseImportJob,
+  useDatabaseImportJob,
+  useRunDatabaseImportJob,
+} from "@/hooks/use-databases";
+
+type WizardStep = "source" | "preflight" | "import";
+
+type DatabaseImportJob = ContractOutputs["databases"]["getImportJob"];
+type DatabaseImportCheck = DatabaseImportJob["checkResults"][number];
+type DatabaseImportVerifyCheck =
+  DatabaseImportJob["verifyResult"]["checks"][number];
+
+interface DatabaseImportWizardProps {
+  projectId: string;
+  initialTargetName: string;
+  onBack: () => void;
+  onFinished?: (databaseId: string) => void;
+}
+
+const WIZARD_STEPS: Array<{
+  id: WizardStep;
+  label: string;
+}> = [
+  { id: "source", label: "Source" },
+  { id: "preflight", label: "Preflight" },
+  { id: "import", label: "Import" },
+];
+
+function getStepIndex(
+  job: {
+    stage: string;
+    databaseId: string | null;
+  } | null,
+): number {
+  if (!job) {
+    return 0;
+  }
+  if (
+    job.stage === "preflight" ||
+    (job.stage === "failed" && !job.databaseId)
+  ) {
+    return 1;
+  }
+  if (
+    job.stage === "target" ||
+    job.stage === "importing" ||
+    job.stage === "imported" ||
+    job.stage === "verifying" ||
+    job.stage === "completed" ||
+    (job.stage === "failed" && job.databaseId)
+  ) {
+    return 2;
+  }
+  return 0;
+}
+
+function getCheckBadgeClass(status: "ok" | "warning" | "blocked"): string {
+  if (status === "ok") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-300";
+  }
+  if (status === "warning") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-300";
+  }
+  return "border-red-500/30 bg-red-500/10 text-red-300";
+}
+
+function getVerifyBadgeClass(status: "pass" | "warning" | "failed"): string {
+  if (status === "pass") {
+    return "border-emerald-500/30 bg-emerald-500/10 text-emerald-300";
+  }
+  if (status === "warning") {
+    return "border-amber-500/30 bg-amber-500/10 text-amber-300";
+  }
+  return "border-red-500/30 bg-red-500/10 text-red-300";
+}
+
+function hasBlockedImportChecks(checkResults: DatabaseImportCheck[]): boolean {
+  return checkResults.some(function hasBlockedCheck(check) {
+    return check.status === "blocked";
+  });
+}
+
+function getConnectionString(input: {
+  username: string;
+  password: string;
+  host: string;
+  port: number;
+  database: string;
+  ssl: boolean;
+}): string {
+  const user = encodeURIComponent(input.username);
+  const password = encodeURIComponent(input.password);
+  const database = encodeURIComponent(input.database);
+  const sslSuffix = input.ssl ? "?sslmode=require" : "";
+  return `postgres://${user}:${password}@${input.host}:${input.port}/${database}${sslSuffix}`;
+}
+
+function getProgressLabel(
+  step: string | null,
+  stage: DatabaseImportJob["stage"] | null,
+): string {
+  if (step === "create-target") {
+    return "creating Frost target";
+  }
+  if (step) {
+    return step;
+  }
+  if (stage === "target") {
+    return "creating Frost target";
+  }
+  if (stage === "importing") {
+    return "running import";
+  }
+  if (stage === "verifying") {
+    return "running verify";
+  }
+  if (stage === "completed") {
+    return "done";
+  }
+  return "idle";
+}
+
+function canStartImport(job: DatabaseImportJob | null): boolean {
+  if (!job) {
+    return false;
+  }
+
+  if (hasBlockedImportChecks(job.checkResults)) {
+    return false;
+  }
+
+  return (
+    job.progressStep === null &&
+    job.stage !== "importing" &&
+    job.stage !== "verifying" &&
+    job.stage !== "completed"
+  );
+}
+
+function getStartImportLabel(job: DatabaseImportJob | null): string {
+  if (!job) {
+    return "Start import";
+  }
+  if (job.databaseId) {
+    return "Run import again";
+  }
+  return "Start import";
+}
+
+export function DatabaseImportWizard({
+  projectId,
+  initialTargetName,
+  onBack,
+  onFinished,
+}: DatabaseImportWizardProps): React.ReactElement {
+  const [jobId, setJobId] = useState("");
+  const [sourceUrl, setSourceUrl] = useState("");
+  const [currentJob, setCurrentJob] = useState<DatabaseImportJob | null>(null);
+  const [externalHost, setExternalHost] = useState("127.0.0.1");
+
+  const createJobMutation = useCreateDatabaseImportJob(projectId);
+  const jobQuery = useDatabaseImportJob(jobId);
+  const runImportMutation = useRunDatabaseImportJob(jobId);
+
+  useEffect(function resolveExternalHost() {
+    if (typeof window === "undefined") {
+      return;
+    }
+    if (window.location.hostname) {
+      setExternalHost(window.location.hostname);
+    }
+  }, []);
+
+  async function handlePreflightSubmit(
+    event: React.FormEvent<HTMLFormElement>,
+  ): Promise<void> {
+    event.preventDefault();
+
+    try {
+      const result = await createJobMutation.mutateAsync({
+        targetName: initialTargetName,
+        sourceUrl,
+      });
+      setJobId(result.id);
+      setCurrentJob(result);
+      if (result.stage === "failed") {
+        toast.error("Preflight found blocked checks");
+        return;
+      }
+      toast.success("Preflight passed");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Preflight failed";
+      toast.error(message);
+    }
+  }
+
+  async function handleStartImport(): Promise<void> {
+    try {
+      const result = await runImportMutation.mutateAsync();
+      setCurrentJob(result);
+      toast.success("Import started");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Failed to start import";
+      toast.error(message);
+    }
+  }
+
+  function handleStartOver(): void {
+    setJobId("");
+    setCurrentJob(null);
+    setSourceUrl("");
+  }
+
+  const job = jobQuery.data ?? currentJob;
+  const currentStepIndex = getStepIndex(job);
+  const hasBlockedChecks = job
+    ? hasBlockedImportChecks(job.checkResults)
+    : false;
+  const canStartImportNow = canStartImport(job);
+  const canFinish = job?.stage === "completed" && job.databaseId;
+  const showStepSpinner =
+    createJobMutation.isPending ||
+    runImportMutation.isPending ||
+    job?.stage === "target" ||
+    job?.stage === "importing" ||
+    job?.stage === "verifying";
+
+  const internalConnectionString = job?.targetConnection
+    ? getConnectionString({
+        username: job.targetConnection.username,
+        password: job.targetConnection.password,
+        host: job.targetConnection.internalHost,
+        port: 5432,
+        database: job.targetConnection.database,
+        ssl: job.targetConnection.ssl,
+      })
+    : "";
+
+  const externalConnectionString = job?.targetConnection
+    ? getConnectionString({
+        username: job.targetConnection.username,
+        password: job.targetConnection.password,
+        host: externalHost,
+        port: job.targetConnection.hostPort,
+        database: job.targetConnection.database,
+        ssl: job.targetConnection.ssl,
+      })
+    : "";
+
+  return (
+    <div className="space-y-4">
+      <button
+        type="button"
+        onClick={onBack}
+        className="text-sm text-neutral-400 hover:text-neutral-200"
+      >
+        Back
+      </button>
+
+      <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+        {WIZARD_STEPS.map(function renderStep(step, index) {
+          const isComplete = index < currentStepIndex;
+          const isCurrent = index === currentStepIndex;
+          return (
+            <div
+              key={step.id}
+              className={`rounded-lg border px-3 py-2 ${
+                isCurrent
+                  ? "border-blue-500/40 bg-blue-500/10"
+                  : "border-neutral-800 bg-neutral-900"
+              }`}
+            >
+              <div className="flex items-center gap-2">
+                {isComplete ? (
+                  <CheckCircle2 className="h-4 w-4 text-emerald-400" />
+                ) : isCurrent && showStepSpinner ? (
+                  <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
+                ) : (
+                  <Circle
+                    className={`h-4 w-4 ${
+                      isCurrent ? "text-blue-400" : "text-neutral-600"
+                    }`}
+                  />
+                )}
+                <span className="text-xs text-neutral-200">{step.label}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {!job && (
+        <form onSubmit={handlePreflightSubmit} className="space-y-3">
+          <div className="space-y-2">
+            <label htmlFor="source_url" className="text-xs text-neutral-400">
+              Source URL
+            </label>
+            <Input
+              id="source_url"
+              value={sourceUrl}
+              onChange={function onSourceUrlChange(event) {
+                setSourceUrl(event.target.value);
+              }}
+              placeholder="postgresql://user:pass@host:5432/app"
+              required
+              className="border-neutral-700 bg-neutral-800 font-mono text-xs text-neutral-100"
+            />
+          </div>
+
+          <Button type="submit" disabled={createJobMutation.isPending}>
+            {createJobMutation.isPending ? (
+              <>
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Running preflight
+              </>
+            ) : (
+              "Run preflight"
+            )}
+          </Button>
+        </form>
+      )}
+
+      {job && (
+        <>
+          <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <div>
+                <p className="text-sm font-medium text-neutral-100">
+                  Source summary
+                </p>
+                <p className="text-xs text-neutral-500">
+                  {job.sourceSummary.host}:{job.sourceSummary.port}/
+                  {job.sourceSummary.database}
+                </p>
+              </div>
+              <Badge
+                variant="outline"
+                className="border-neutral-700 text-neutral-300"
+              >
+                {job.sourceSummary.serverVersion ?? "version unknown"}
+              </Badge>
+            </div>
+
+            <div className="mt-3 grid grid-cols-2 gap-3 text-xs text-neutral-400">
+              <div>
+                <p>Estimated downtime</p>
+                <p className="text-neutral-200">
+                  {job.sourceSummary.estimatedDowntimeMinutes
+                    ? `${job.sourceSummary.estimatedDowntimeMinutes} min`
+                    : "unknown"}
+                </p>
+              </div>
+              <div>
+                <p>Database size</p>
+                <p className="text-neutral-200">
+                  {job.sourceSummary.sizeBytes !== null
+                    ? `${Math.max(1, Math.round(job.sourceSummary.sizeBytes / (1024 * 1024)))} MB`
+                    : "unknown"}
+                </p>
+              </div>
+              <div>
+                <p>Tables</p>
+                <p className="text-neutral-200">
+                  {job.sourceSummary.tableCount ?? "unknown"}
+                </p>
+              </div>
+              <div>
+                <p>Write activity</p>
+                <p className="text-neutral-200">
+                  {job.sourceSummary.writeActivity ?? "unknown"}
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm font-medium text-neutral-100">
+                Preflight checks
+              </p>
+              {hasBlockedChecks && (
+                <div className="flex items-center gap-2 text-xs text-red-300">
+                  <AlertTriangle className="h-4 w-4" />
+                  Blocked
+                </div>
+              )}
+            </div>
+            <div className="mt-3 space-y-2">
+              {job.checkResults.map(function renderCheck(
+                check: DatabaseImportCheck,
+              ) {
+                return (
+                  <div
+                    key={check.key}
+                    className="flex items-start justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                  >
+                    <div className="min-w-0">
+                      <p className="text-sm text-neutral-100">{check.label}</p>
+                      <p className="text-xs text-neutral-500">
+                        {check.message}
+                      </p>
+                    </div>
+                    <Badge
+                      variant="outline"
+                      className={getCheckBadgeClass(check.status)}
+                    >
+                      {check.status}
+                    </Badge>
+                  </div>
+                );
+              })}
+            </div>
+            {!job.databaseId && (
+              <div className="mt-4 flex gap-2">
+                {canStartImportNow && (
+                  <Button
+                    type="button"
+                    onClick={handleStartImport}
+                    disabled={runImportMutation.isPending}
+                  >
+                    {runImportMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Starting import
+                      </>
+                    ) : (
+                      getStartImportLabel(job)
+                    )}
+                  </Button>
+                )}
+                <Button type="button" variant="ghost" onClick={handleStartOver}>
+                  Start over
+                </Button>
+              </div>
+            )}
+          </div>
+
+          {job.errorMessage && (
+            <div className="rounded-lg border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-200">
+              {job.errorMessage}
+            </div>
+          )}
+
+          {job.databaseId && (
+            <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+              <div className="flex items-center justify-between gap-3">
+                <div>
+                  <p className="text-sm font-medium text-neutral-100">
+                    Import progress
+                  </p>
+                  <p className="text-xs text-neutral-500">
+                    {getProgressLabel(job.progressStep, job.stage)}
+                  </p>
+                </div>
+                {(job.stage === "target" ||
+                  job.stage === "importing" ||
+                  job.stage === "verifying") && (
+                  <Loader2 className="h-4 w-4 animate-spin text-blue-400" />
+                )}
+              </div>
+              <div className="mt-3 space-y-3">
+                <div className="space-y-2">
+                  <p className="text-xs text-neutral-400">
+                    External connection
+                  </p>
+                  <Input
+                    readOnly
+                    value={externalConnectionString}
+                    className="border-neutral-700 bg-neutral-800 font-mono text-[11px] text-neutral-100"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <p className="text-xs text-neutral-400">
+                    Internal connection
+                  </p>
+                  <Input
+                    readOnly
+                    value={internalConnectionString}
+                    className="border-neutral-700 bg-neutral-800 font-mono text-[11px] text-neutral-100"
+                  />
+                </div>
+              </div>
+              <textarea
+                readOnly
+                value={job.logText}
+                className="mt-3 h-48 w-full rounded-lg border border-neutral-800 bg-neutral-950 p-3 font-mono text-[11px] text-neutral-200 outline-none"
+              />
+              {job.stage === "failed" && canStartImportNow && (
+                <div className="mt-4">
+                  <Button
+                    type="button"
+                    onClick={handleStartImport}
+                    disabled={runImportMutation.isPending}
+                  >
+                    {runImportMutation.isPending ? (
+                      <>
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                        Starting import
+                      </>
+                    ) : (
+                      getStartImportLabel(job)
+                    )}
+                  </Button>
+                </div>
+              )}
+              {job.stage === "completed" && (
+                <div className="mt-4 border-t border-neutral-800 pt-4">
+                  <div className="flex items-center justify-between gap-3">
+                    <p className="text-sm font-medium text-neutral-100">
+                      Import completed
+                    </p>
+                    <Badge
+                      variant="outline"
+                      className="border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                    >
+                      complete
+                    </Badge>
+                  </div>
+                  <ul className="mt-3 list-disc space-y-2 pl-5 text-xs text-neutral-400">
+                    <li>Pause writes to the old database</li>
+                    <li>Stop workers and cron jobs</li>
+                    <li>Switch the app to the new connection string</li>
+                    <li>Smoke test reads and writes</li>
+                  </ul>
+                  <div className="mt-4 flex gap-2">
+                    <Button
+                      type="button"
+                      onClick={function onOpenDatabase() {
+                        const databaseId = job.databaseId;
+                        if (canFinish && onFinished && databaseId) {
+                          onFinished(databaseId);
+                        }
+                      }}
+                      disabled={!canFinish}
+                    >
+                      Open database
+                    </Button>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      onClick={handleStartOver}
+                    >
+                      New import
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+
+          {job.verifyResult.checks.length > 0 && (
+            <div className="rounded-lg border border-neutral-800 bg-neutral-900 p-4">
+              <p className="text-sm font-medium text-neutral-100">
+                Verify result
+              </p>
+              <div className="mt-3 space-y-2">
+                {job.verifyResult.checks.map(function renderVerifyCheck(
+                  check: DatabaseImportVerifyCheck,
+                ) {
+                  return (
+                    <div
+                      key={check.key}
+                      className="flex items-start justify-between gap-3 rounded-lg border border-neutral-800 bg-neutral-950/60 px-3 py-2"
+                    >
+                      <div className="min-w-0">
+                        <p className="text-sm text-neutral-100">
+                          {check.label}
+                        </p>
+                        <p className="text-xs text-neutral-500">
+                          {check.message}
+                        </p>
+                      </div>
+                      <Badge
+                        variant="outline"
+                        className={getVerifyBadgeClass(check.status)}
+                      >
+                        {check.status}
+                      </Badge>
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -7,6 +7,23 @@ const databaseTargetKindSchema = z.enum(["branch", "instance"]);
 const databaseTargetLifecycleSchema = z.enum(["active", "stopped", "expired"]);
 const databaseStorageBackendSchema = z.enum(["apfs", "copy", "zfs"]);
 const backupIntervalUnitSchema = z.enum(["minutes", "hours", "days"]);
+const databaseImportStageSchema = z.enum([
+  "source",
+  "preflight",
+  "target",
+  "importing",
+  "imported",
+  "verifying",
+  "ready-for-cutover",
+  "completed",
+  "failed",
+]);
+const databaseImportStrategySchema = z.enum([
+  "dump-restore",
+  "logical-replication",
+]);
+const databaseImportCheckStatusSchema = z.enum(["ok", "warning", "blocked"]);
+const databaseImportVerifyStatusSchema = z.enum(["pass", "warning", "failed"]);
 const backupS3ProviderSchema = z.enum([
   "aws",
   "cloudflare",
@@ -163,6 +180,79 @@ const databaseBackupRestoreResultSchema = z.object({
   warnings: z.array(z.string()),
 });
 
+const databaseImportCheckResultSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  status: databaseImportCheckStatusSchema,
+  message: z.string(),
+});
+
+const databaseImportSourceSummarySchema = z.object({
+  host: z.string(),
+  port: z.number(),
+  database: z.string(),
+  username: z.string(),
+  sslMode: z.string(),
+  serverVersion: z.string().nullable(),
+  estimatedDowntimeMinutes: z.number().nullable(),
+  sizeBytes: z.number().nullable(),
+  tableCount: z.number().nullable(),
+  extensionNames: z.array(z.string()),
+  owner: z.string().nullable(),
+  currentUser: z.string().nullable(),
+  activeConnectionCount: z.number().nullable(),
+  longRunningConnectionCount: z.number().nullable(),
+  activeWriteConnectionCount: z.number().nullable(),
+  writeActivity: z.enum(["quiet", "active"]).nullable(),
+  unsupportedExtensions: z.array(z.string()),
+});
+
+const databaseImportVerifyCheckSchema = z.object({
+  key: z.string(),
+  label: z.string(),
+  status: databaseImportVerifyStatusSchema,
+  message: z.string(),
+});
+
+const databaseImportVerifyResultSchema = z.object({
+  status: databaseImportVerifyStatusSchema,
+  checks: z.array(databaseImportVerifyCheckSchema),
+  comparedAt: z.number().nullable(),
+});
+
+const databaseImportTargetConnectionSchema = z.object({
+  databaseId: z.string(),
+  targetId: z.string(),
+  internalHost: z.string(),
+  hostPort: z.number(),
+  username: z.string(),
+  password: z.string(),
+  database: z.string(),
+  ssl: z.boolean(),
+});
+
+const databaseImportJobSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  databaseId: z.string().nullable(),
+  targetName: z.string(),
+  engine: z.literal("postgres"),
+  strategy: databaseImportStrategySchema,
+  stage: databaseImportStageSchema,
+  progressStep: z.string().nullable(),
+  sourceSummary: databaseImportSourceSummarySchema,
+  checkResults: z.array(databaseImportCheckResultSchema),
+  verifyResult: databaseImportVerifyResultSchema,
+  logText: z.string(),
+  errorMessage: z.string().nullable(),
+  cutoverConfirmedAt: z.number().nullable(),
+  completedAt: z.number().nullable(),
+  failedAt: z.number().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  targetConnection: databaseImportTargetConnectionSchema.nullable(),
+});
+
 const targetParamsSchema = z.object({
   databaseId: z.string(),
   targetId: z.string(),
@@ -258,6 +348,68 @@ export const databasesContract = {
       }),
     )
     .output(databaseBackupRestoreResultSchema),
+
+  createImportJob: oc
+    .route({
+      method: "POST",
+      path: "/projects/{projectId}/database-import-jobs",
+    })
+    .input(
+      z.object({
+        projectId: z.string(),
+        targetName: z.string().min(1),
+        sourceUrl: z.string().min(1),
+      }),
+    )
+    .output(databaseImportJobSchema),
+
+  getImportJob: oc
+    .route({
+      method: "GET",
+      path: "/database-import-jobs/{jobId}",
+    })
+    .input(z.object({ jobId: z.string() }))
+    .output(databaseImportJobSchema),
+
+  listImportJobs: oc
+    .route({
+      method: "GET",
+      path: "/databases/{databaseId}/import-jobs",
+    })
+    .input(z.object({ databaseId: z.string() }))
+    .output(z.array(databaseImportJobSchema)),
+
+  createImportTarget: oc
+    .route({
+      method: "POST",
+      path: "/database-import-jobs/{jobId}/target",
+    })
+    .input(z.object({ jobId: z.string() }))
+    .output(databaseImportJobSchema),
+
+  runImportJob: oc
+    .route({
+      method: "POST",
+      path: "/database-import-jobs/{jobId}/import",
+    })
+    .input(z.object({ jobId: z.string() }))
+    .output(databaseImportJobSchema),
+
+  runImportVerify: oc
+    .route({
+      method: "POST",
+      path: "/database-import-jobs/{jobId}/verify",
+    })
+    .input(z.object({ jobId: z.string() }))
+    .output(databaseImportJobSchema),
+
+  markImportCutover: oc
+    .route({
+      method: "POST",
+      path: "/database-import-jobs/{jobId}/cutover",
+    })
+    .input(z.object({ jobId: z.string() }))
+    .output(databaseImportJobSchema),
 
   delete: oc
     .route({ method: "DELETE", path: "/databases/{databaseId}" })

--- a/apps/app/src/hooks/use-databases.ts
+++ b/apps/app/src/hooks/use-databases.ts
@@ -16,6 +16,22 @@ export function useDatabase(databaseId: string) {
   });
 }
 
+export function useDatabaseImportJob(jobId: string) {
+  return useQuery({
+    ...orpc.databases.getImportJob.queryOptions({ input: { jobId } }),
+    enabled: !!jobId,
+    refetchInterval: 2000,
+  });
+}
+
+export function useDatabaseImportJobs(databaseId: string) {
+  return useQuery({
+    ...orpc.databases.listImportJobs.queryOptions({ input: { databaseId } }),
+    enabled: !!databaseId,
+    refetchInterval: 5000,
+  });
+}
+
 export function useUpdateDatabase(databaseId: string, projectId: string) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -104,6 +120,33 @@ export function useCreateDatabase(projectId: string) {
       await queryClient.refetchQueries({
         queryKey: orpc.databases.list.key({ input: { projectId } }),
       });
+    },
+  });
+}
+
+export function useCreateDatabaseImportJob(projectId: string) {
+  return useMutation({
+    mutationFn: (
+      data: Omit<ContractInputs["databases"]["createImportJob"], "projectId">,
+    ) => orpc.databases.createImportJob.call({ projectId, ...data }),
+  });
+}
+
+export function useRunDatabaseImportJob(jobId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => orpc.databases.runImportJob.call({ jobId }),
+    onSuccess: async (result) => {
+      await queryClient.refetchQueries({
+        queryKey: orpc.databases.getImportJob.key({ input: { jobId } }),
+      });
+      if (result.databaseId) {
+        await queryClient.refetchQueries({
+          queryKey: orpc.databases.listImportJobs.key({
+            input: { databaseId: result.databaseId },
+          }),
+        });
+      }
     },
   });
 }

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -509,13 +509,15 @@ async function createTargetRuntime(input: {
   targetName: string;
   runtimeServiceId: string;
   engine: DatabaseEngine;
+  image?: string;
   memoryLimit?: string | null;
   cpuLimit?: number | null;
   templateRef?: ProviderRef;
   fixedHostPort?: number;
   storageMountPath?: string;
 }): Promise<ProviderRef> {
-  const image = input.templateRef?.image ?? getDefaultImage(input.engine);
+  const image =
+    input.image ?? input.templateRef?.image ?? getDefaultImage(input.engine);
   const port = input.templateRef?.port ?? getDefaultPort(input.engine);
   const username = input.templateRef?.username ?? "frost";
   const password = input.templateRef?.password ?? randomSecret();
@@ -918,6 +920,7 @@ export async function createDatabase(input: {
   projectId: string;
   name: string;
   engine: DatabaseEngine;
+  image?: string;
 }): Promise<DatabaseWithTarget> {
   assertDatabaseName(input.name);
 
@@ -991,6 +994,7 @@ export async function createDatabase(input: {
       targetName: "main",
       runtimeServiceId,
       engine: input.engine,
+      image: input.image,
       storageMountPath,
     });
     rollback.add(async () => {

--- a/apps/app/src/lib/db-schemas.ts
+++ b/apps/app/src/lib/db-schemas.ts
@@ -758,6 +758,127 @@ export type ServiceDatabaseBindingsUpdate = z.infer<
   typeof serviceDatabaseBindingsUpdateSchema
 >;
 
+export const databaseImportJobsSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  databaseId: z.string().nullable(),
+  targetName: z.string(),
+  engine: z.enum(["postgres"]),
+  strategy: z.enum(["dump-restore", "logical-replication"]),
+  sourceUrlEncrypted: z.string().nullable(),
+  sourceHost: z.string(),
+  sourcePort: z.number(),
+  sourceDatabase: z.string(),
+  sourceUsername: z.string(),
+  sourceSslMode: z.string(),
+  stage: z.enum([
+    "source",
+    "preflight",
+    "target",
+    "importing",
+    "imported",
+    "verifying",
+    "ready-for-cutover",
+    "completed",
+    "failed",
+  ]),
+  progressStep: z.string().nullable(),
+  sourceSummaryJson: z.string(),
+  checkResultsJson: z.string(),
+  verifyResultJson: z.string(),
+  logText: z.string(),
+  errorMessage: z.string().nullable(),
+  cutoverConfirmedAt: z.number().nullable(),
+  completedAt: z.number().nullable(),
+  failedAt: z.number().nullable(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const newDatabaseImportJobsSchema = z.object({
+  id: z.string(),
+  projectId: z.string(),
+  databaseId: z.string().nullable(),
+  targetName: z.string(),
+  engine: z.enum(["postgres"]).optional(),
+  strategy: z.enum(["dump-restore", "logical-replication"]).optional(),
+  sourceUrlEncrypted: z.string().nullable().optional(),
+  sourceHost: z.string(),
+  sourcePort: z.number(),
+  sourceDatabase: z.string(),
+  sourceUsername: z.string(),
+  sourceSslMode: z.string(),
+  stage: z
+    .enum([
+      "source",
+      "preflight",
+      "target",
+      "importing",
+      "imported",
+      "verifying",
+      "ready-for-cutover",
+      "completed",
+      "failed",
+    ])
+    .optional(),
+  progressStep: z.string().nullable().optional(),
+  sourceSummaryJson: z.string().optional(),
+  checkResultsJson: z.string().optional(),
+  verifyResultJson: z.string().optional(),
+  logText: z.string().optional(),
+  errorMessage: z.string().nullable().optional(),
+  cutoverConfirmedAt: z.number().nullable().optional(),
+  completedAt: z.number().nullable().optional(),
+  failedAt: z.number().nullable().optional(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+
+export const databaseImportJobsUpdateSchema = z.object({
+  id: z.string().optional(),
+  projectId: z.string().optional(),
+  databaseId: z.string().nullable().optional(),
+  targetName: z.string().optional(),
+  engine: z.enum(["postgres"]).optional(),
+  strategy: z.enum(["dump-restore", "logical-replication"]).optional(),
+  sourceUrlEncrypted: z.string().nullable().optional(),
+  sourceHost: z.string().optional(),
+  sourcePort: z.number().optional(),
+  sourceDatabase: z.string().optional(),
+  sourceUsername: z.string().optional(),
+  sourceSslMode: z.string().optional(),
+  stage: z
+    .enum([
+      "source",
+      "preflight",
+      "target",
+      "importing",
+      "imported",
+      "verifying",
+      "ready-for-cutover",
+      "completed",
+      "failed",
+    ])
+    .optional(),
+  progressStep: z.string().nullable().optional(),
+  sourceSummaryJson: z.string().optional(),
+  checkResultsJson: z.string().optional(),
+  verifyResultJson: z.string().optional(),
+  logText: z.string().optional(),
+  errorMessage: z.string().nullable().optional(),
+  cutoverConfirmedAt: z.number().nullable().optional(),
+  completedAt: z.number().nullable().optional(),
+  failedAt: z.number().nullable().optional(),
+  createdAt: z.number().optional(),
+  updatedAt: z.number().optional(),
+});
+
+export type DatabaseImportJobs = z.infer<typeof databaseImportJobsSchema>;
+export type NewDatabaseImportJobs = z.infer<typeof newDatabaseImportJobsSchema>;
+export type DatabaseImportJobsUpdate = z.infer<
+  typeof databaseImportJobsUpdateSchema
+>;
+
 export const databaseBackupConfigsSchema = z.object({
   databaseId: z.string(),
   enabled: z.boolean(),

--- a/apps/app/src/lib/db-types.ts
+++ b/apps/app/src/lib/db-types.ts
@@ -59,6 +59,33 @@ export interface DatabaseBackupConfigs {
   updatedAt: number;
 }
 
+export interface DatabaseImportJobs {
+  id: string;
+  projectId: string;
+  databaseId: string | null;
+  targetName: string;
+  engine: 'postgres';
+  strategy: Generated<'dump-restore' | 'logical-replication'>;
+  sourceUrlEncrypted: string | null;
+  sourceHost: string;
+  sourcePort: number;
+  sourceDatabase: string;
+  sourceUsername: string;
+  sourceSslMode: string;
+  stage: 'source' | 'preflight' | 'target' | 'importing' | 'imported' | 'verifying' | 'ready-for-cutover' | 'completed' | 'failed';
+  progressStep: string | null;
+  sourceSummaryJson: Generated<string>;
+  checkResultsJson: Generated<string>;
+  verifyResultJson: Generated<string>;
+  logText: Generated<string>;
+  errorMessage: string | null;
+  cutoverConfirmedAt: number | null;
+  completedAt: number | null;
+  failedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
 export interface DatabaseTargetDeployments {
   id: string;
   targetId: string;
@@ -291,6 +318,7 @@ export interface DB {
   _Migrations: Migrations;
   apiKeys: ApiKeys;
   databaseBackupConfigs: DatabaseBackupConfigs;
+  databaseImportJobs: DatabaseImportJobs;
   databaseTargetDeployments: DatabaseTargetDeployments;
   databaseTargets: DatabaseTargets;
   databases: Databases;

--- a/apps/app/src/lib/id.ts
+++ b/apps/app/src/lib/id.ts
@@ -52,6 +52,10 @@ export function newDatabaseTargetDeploymentId(): string {
   return buildId("dtd");
 }
 
+export function newDatabaseImportJobId(): string {
+  return buildId("dbi");
+}
+
 export function newEnvironmentDatabaseAttachmentId(): string {
   return buildId("att");
 }

--- a/apps/app/src/lib/postgres-import.integration.test.ts
+++ b/apps/app/src/lib/postgres-import.integration.test.ts
@@ -1,0 +1,245 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { exec } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { promisify } from "node:util";
+import { deleteDatabase } from "./database-runtime";
+import { db } from "./db";
+import { runMigrations } from "./migrate";
+import {
+  createDatabaseImportJob,
+  getDatabaseImportJob,
+  triggerDatabaseImport,
+} from "./postgres-import";
+import { shellEscape } from "./shell-escape";
+
+const execAsync = promisify(exec);
+
+const SOURCE_CONTAINER = "frost-test-postgres-import-source";
+let sourcePort = 0;
+
+async function startSourcePostgres(): Promise<number> {
+  await execAsync(`docker rm -f ${SOURCE_CONTAINER}`).catch(
+    function ignore() {},
+  );
+  await execAsync(
+    `docker run -d --name ${SOURCE_CONTAINER} -P ` +
+      `-e POSTGRES_USER=source -e POSTGRES_PASSWORD=secret -e POSTGRES_DB=source_app ` +
+      `postgres:17-alpine`,
+  );
+
+  const { stdout } = await execAsync(
+    `docker port ${SOURCE_CONTAINER} 5432/tcp`,
+  );
+  const firstLine = stdout
+    .split("\n")
+    .map(function trimLine(line) {
+      return line.trim();
+    })
+    .find(function hasValue(line) {
+      return line.length > 0;
+    });
+
+  if (!firstLine) {
+    throw new Error("Source postgres port mapping missing");
+  }
+
+  const port = Number(firstLine.split(":").pop());
+  if (!Number.isInteger(port) || port < 1) {
+    throw new Error(`Invalid source postgres port: ${firstLine}`);
+  }
+
+  return port;
+}
+
+async function waitForSourceReady(): Promise<void> {
+  for (let attempt = 1; attempt <= 60; attempt += 1) {
+    try {
+      await execAsync(
+        `docker exec ${SOURCE_CONTAINER} pg_isready -h 127.0.0.1 -U source -d source_app`,
+      );
+      return;
+    } catch {
+      await new Promise(function wait(resolve) {
+        setTimeout(resolve, 1000);
+      });
+    }
+  }
+
+  throw new Error("Source postgres did not become ready");
+}
+
+async function runSourceSql(sql: string): Promise<void> {
+  await execAsync(
+    `docker exec -e PGPASSWORD=secret ${SOURCE_CONTAINER} ` +
+      `psql -X -v ON_ERROR_STOP=1 -h 127.0.0.1 -U source -d source_app -c ${shellEscape(sql)}`,
+  );
+}
+
+async function readTargetValue(input: {
+  containerName: string;
+  username: string;
+  password: string;
+  database: string;
+  sql: string;
+}): Promise<string> {
+  const { stdout } = await execAsync(
+    `docker exec -e PGPASSWORD=${shellEscape(input.password)} ${shellEscape(input.containerName)} ` +
+      `psql -X -t -A -h 127.0.0.1 -U ${shellEscape(input.username)} -d ${shellEscape(input.database)} -c ${shellEscape(input.sql)}`,
+  );
+  return stdout.trim();
+}
+
+async function waitForImportJobStage(input: {
+  jobId: string;
+  expectedStage: "completed" | "failed";
+}): Promise<Awaited<ReturnType<typeof getDatabaseImportJob>>> {
+  for (let attempt = 1; attempt <= 120; attempt += 1) {
+    const job = await getDatabaseImportJob(input.jobId);
+    if (job.stage === input.expectedStage || job.stage === "failed") {
+      return job;
+    }
+    await new Promise(function wait(resolve) {
+      setTimeout(resolve, 1000);
+    });
+  }
+
+  throw new Error(`Import job did not reach ${input.expectedStage}`);
+}
+
+describe("postgres import integration", () => {
+  beforeAll(async function setup() {
+    runMigrations();
+    sourcePort = await startSourcePostgres();
+    await waitForSourceReady();
+  }, 180000);
+
+  afterAll(async function teardown() {
+    await execAsync(`docker rm -f ${SOURCE_CONTAINER}`).catch(
+      function ignore() {},
+    );
+  });
+
+  test("imports an existing postgres database", async function importExistingPostgres() {
+    const projectId = randomUUID();
+    const projectName = `proj-${projectId.slice(0, 8)}`;
+    const sourceUrl = `postgresql://source:secret@127.0.0.1:${sourcePort}/source_app?sslmode=disable`;
+    let databaseId: string | null = null;
+
+    await db
+      .insertInto("projects")
+      .values({
+        id: projectId,
+        name: projectName,
+        hostname: null,
+        createdAt: Date.now(),
+      })
+      .execute();
+
+    try {
+      await runSourceSql("DROP TABLE IF EXISTS import_users;");
+      await runSourceSql(
+        "CREATE TABLE import_users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
+      );
+      await runSourceSql(
+        "INSERT INTO import_users(name) VALUES ('alice'), ('bob');",
+      );
+
+      const preflightJob = await createDatabaseImportJob({
+        projectId,
+        targetName: "prod-db",
+        sourceUrl,
+      });
+      expect(preflightJob.stage).toBe("preflight");
+
+      const importJob = await triggerDatabaseImport(preflightJob.id);
+      databaseId = importJob.databaseId;
+      expect(databaseId).not.toBeNull();
+
+      const completedJob = await waitForImportJobStage({
+        jobId: preflightJob.id,
+        expectedStage: "completed",
+      });
+      expect(completedJob.stage).toBe("completed");
+      expect(completedJob.targetConnection).not.toBeNull();
+
+      const targetConnection = completedJob.targetConnection;
+      if (!targetConnection) {
+        throw new Error("Target connection missing");
+      }
+      if (!databaseId) {
+        throw new Error("Database id missing");
+      }
+
+      const target = await db
+        .selectFrom("databaseTargets")
+        .select("providerRefJson")
+        .where("databaseId", "=", databaseId)
+        .where("name", "=", "main")
+        .executeTakeFirst();
+
+      if (!target) {
+        throw new Error("Target runtime missing");
+      }
+
+      const providerRef = JSON.parse(target.providerRefJson) as {
+        containerName: string;
+        image: string;
+      };
+      expect(providerRef.image).toBe("postgres:17");
+
+      const importedCount = await readTargetValue({
+        containerName: providerRef.containerName,
+        username: targetConnection.username,
+        password: targetConnection.password,
+        database: targetConnection.database,
+        sql: "SELECT count(*) FROM import_users;",
+      });
+      expect(importedCount).toBe("2");
+    } finally {
+      if (databaseId) {
+        await deleteDatabase(databaseId).catch(function ignore() {});
+      }
+      await db
+        .deleteFrom("databaseImportJobs")
+        .where("projectId", "=", projectId)
+        .execute();
+      await db.deleteFrom("projects").where("id", "=", projectId).execute();
+    }
+  }, 180000);
+
+  test("fails preflight when credentials are wrong", async function failPreflight() {
+    const projectId = randomUUID();
+    const projectName = `proj-${projectId.slice(0, 8)}`;
+
+    await db
+      .insertInto("projects")
+      .values({
+        id: projectId,
+        name: projectName,
+        hostname: null,
+        createdAt: Date.now(),
+      })
+      .execute();
+
+    try {
+      const job = await createDatabaseImportJob({
+        projectId,
+        targetName: "blocked-db",
+        sourceUrl: `postgresql://source:wrong@127.0.0.1:${sourcePort}/source_app?sslmode=disable`,
+      });
+
+      expect(job.stage).toBe("failed");
+      expect(
+        job.checkResults.some(function hasBlockedCheck(check) {
+          return check.status === "blocked";
+        }),
+      ).toBe(true);
+    } finally {
+      await db
+        .deleteFrom("databaseImportJobs")
+        .where("projectId", "=", projectId)
+        .execute();
+      await db.deleteFrom("projects").where("id", "=", projectId).execute();
+    }
+  }, 180000);
+});

--- a/apps/app/src/lib/postgres-import.integration.test.ts
+++ b/apps/app/src/lib/postgres-import.integration.test.ts
@@ -137,6 +137,7 @@ describe("postgres import integration", () => {
 
     try {
       await runSourceSql("DROP TABLE IF EXISTS import_users;");
+      await runSourceSql("CREATE EXTENSION IF NOT EXISTS pg_trgm;");
       await runSourceSql(
         "CREATE TABLE import_users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);",
       );
@@ -150,6 +151,11 @@ describe("postgres import integration", () => {
         sourceUrl,
       });
       expect(preflightJob.stage).toBe("preflight");
+      expect(
+        preflightJob.checkResults.find(function findCheck(check) {
+          return check.key === "extensions";
+        })?.status,
+      ).toBe("ok");
 
       const importJob = await triggerDatabaseImport(preflightJob.id);
       databaseId = importJob.databaseId;
@@ -195,6 +201,15 @@ describe("postgres import integration", () => {
         sql: "SELECT count(*) FROM import_users;",
       });
       expect(importedCount).toBe("2");
+
+      const importedExtension = await readTargetValue({
+        containerName: providerRef.containerName,
+        username: targetConnection.username,
+        password: targetConnection.password,
+        database: targetConnection.database,
+        sql: "SELECT extname FROM pg_extension WHERE extname = 'pg_trgm';",
+      });
+      expect(importedExtension).toBe("pg_trgm");
     } finally {
       if (databaseId) {
         await deleteDatabase(databaseId).catch(function ignore() {});

--- a/apps/app/src/lib/postgres-import.ts
+++ b/apps/app/src/lib/postgres-import.ts
@@ -985,7 +985,7 @@ async function listSupportedExtensions(image: string): Promise<Set<string>> {
       image,
       "sh",
       "-lc",
-      'for f in /usr/local/share/postgresql/extension/*.control; do basename "$f" .control; done | sort',
+      'find /usr/local/share/postgresql /usr/share/postgresql -path "*/extension/*.control" -print 2>/dev/null | while read -r f; do basename "$f" .control; done | sort -u',
     ]);
 
     const extensionNames = result.stdout

--- a/apps/app/src/lib/postgres-import.ts
+++ b/apps/app/src/lib/postgres-import.ts
@@ -1,0 +1,1971 @@
+import { spawn } from "node:child_process";
+import { createWriteStream } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createInterface } from "node:readline";
+import type { Selectable } from "kysely";
+import { decrypt, encrypt } from "./crypto";
+import { getDatabaseBranchInternalHost } from "./database-hostname";
+import { createDatabase, startDatabaseTarget } from "./database-runtime";
+import { db } from "./db";
+import type {
+  DatabaseImportJobs,
+  Databases,
+  DatabaseTargets,
+} from "./db-types";
+import { newDatabaseImportJobId } from "./id";
+
+type DatabaseImportStage =
+  | "source"
+  | "preflight"
+  | "target"
+  | "importing"
+  | "imported"
+  | "verifying"
+  | "ready-for-cutover"
+  | "completed"
+  | "failed";
+
+type DatabaseImportStrategy = "dump-restore" | "logical-replication";
+type DatabaseImportCheckStatus = "ok" | "warning" | "blocked";
+type DatabaseImportVerifyStatus = "pass" | "warning" | "failed";
+type DatabaseImportWriteActivity = "quiet" | "active";
+
+interface ParsedSourceUrl {
+  host: string;
+  clientHost: string;
+  port: number;
+  database: string;
+  username: string;
+  password: string;
+  sslMode: string;
+  addHostGateway: boolean;
+  unsupportedParams: string[];
+}
+
+export interface DatabaseImportCheckResult {
+  key: string;
+  label: string;
+  status: DatabaseImportCheckStatus;
+  message: string;
+}
+
+export interface DatabaseImportSourceSummary {
+  host: string;
+  port: number;
+  database: string;
+  username: string;
+  sslMode: string;
+  serverVersion: string | null;
+  estimatedDowntimeMinutes: number | null;
+  sizeBytes: number | null;
+  tableCount: number | null;
+  extensionNames: string[];
+  owner: string | null;
+  currentUser: string | null;
+  activeConnectionCount: number | null;
+  longRunningConnectionCount: number | null;
+  activeWriteConnectionCount: number | null;
+  writeActivity: DatabaseImportWriteActivity | null;
+  unsupportedExtensions: string[];
+}
+
+export interface DatabaseImportVerifyCheck {
+  key: string;
+  label: string;
+  status: DatabaseImportVerifyStatus;
+  message: string;
+}
+
+export interface DatabaseImportVerifyResult {
+  status: DatabaseImportVerifyStatus;
+  checks: DatabaseImportVerifyCheck[];
+  comparedAt: number | null;
+}
+
+export interface DatabaseImportTargetConnection {
+  databaseId: string;
+  targetId: string;
+  internalHost: string;
+  hostPort: number;
+  username: string;
+  password: string;
+  database: string;
+  ssl: boolean;
+}
+
+export interface DatabaseImportJobView {
+  id: string;
+  projectId: string;
+  databaseId: string | null;
+  targetName: string;
+  engine: "postgres";
+  strategy: DatabaseImportStrategy;
+  stage: DatabaseImportStage;
+  progressStep: string | null;
+  sourceSummary: DatabaseImportSourceSummary;
+  checkResults: DatabaseImportCheckResult[];
+  verifyResult: DatabaseImportVerifyResult;
+  logText: string;
+  errorMessage: string | null;
+  cutoverConfirmedAt: number | null;
+  completedAt: number | null;
+  failedAt: number | null;
+  createdAt: number;
+  updatedAt: number;
+  targetConnection: DatabaseImportTargetConnection | null;
+}
+
+type DatabaseImportRow = Selectable<DatabaseImportJobs>;
+
+interface DatabaseTargetProviderRef {
+  containerName: string;
+  hostPort: number;
+  username: string;
+  password: string;
+  database: string;
+  ssl: boolean;
+  image: string;
+  port: number;
+}
+
+interface ImportCommandResult {
+  stdout: string;
+  stderr: string;
+}
+
+interface DatabaseImportJobUpdate {
+  databaseId?: string | null;
+  targetName?: string;
+  engine?: "postgres";
+  strategy?: DatabaseImportStrategy;
+  sourceUrlEncrypted?: string | null;
+  sourceHost?: string;
+  sourcePort?: number;
+  sourceDatabase?: string;
+  sourceUsername?: string;
+  sourceSslMode?: string;
+  stage?: DatabaseImportStage;
+  progressStep?: string | null;
+  sourceSummaryJson?: string;
+  checkResultsJson?: string;
+  verifyResultJson?: string;
+  logText?: string;
+  errorMessage?: string | null;
+  cutoverConfirmedAt?: number | null;
+  completedAt?: number | null;
+  failedAt?: number | null;
+  createdAt?: number;
+}
+
+const IMPORT_LOG_LIMIT = 200000;
+const PREVIEW_TARGET_VERSION_MIN = 13;
+const TARGET_READY_MAX_ATTEMPTS = 60;
+const TARGET_READY_DELAY_MS = 1000;
+const activeImportJobs = new Set<string>();
+const activeVerifyJobs = new Set<string>();
+const supportedExtensionsPromises = new Map<string, Promise<Set<string>>>();
+
+function getDefaultPostgresImage(): string {
+  return process.env.FROST_POSTGRES_IMAGE ?? "postgres:16";
+}
+
+function getPostgresImageForVersion(versionMajor: number | null): string {
+  if (versionMajor === null) {
+    return getDefaultPostgresImage();
+  }
+
+  return `postgres:${versionMajor}`;
+}
+
+function isAllowedSslMode(value: string): boolean {
+  return [
+    "disable",
+    "allow",
+    "prefer",
+    "require",
+    "verify-ca",
+    "verify-full",
+  ].includes(value);
+}
+
+function safeJsonParse<T>(value: string | null | undefined, fallback: T): T {
+  if (!value) {
+    return fallback;
+  }
+  try {
+    return JSON.parse(value) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+function emptySourceSummary(): DatabaseImportSourceSummary {
+  return {
+    host: "",
+    port: 5432,
+    database: "",
+    username: "",
+    sslMode: "prefer",
+    serverVersion: null,
+    estimatedDowntimeMinutes: null,
+    sizeBytes: null,
+    tableCount: null,
+    extensionNames: [],
+    owner: null,
+    currentUser: null,
+    activeConnectionCount: null,
+    longRunningConnectionCount: null,
+    activeWriteConnectionCount: null,
+    writeActivity: null,
+    unsupportedExtensions: [],
+  };
+}
+
+function emptyVerifyResult(): DatabaseImportVerifyResult {
+  return {
+    status: "pass",
+    checks: [],
+    comparedAt: null,
+  };
+}
+
+function parseSourceUrl(sourceUrl: string): ParsedSourceUrl {
+  let parsed: URL;
+  try {
+    parsed = new URL(sourceUrl);
+  } catch {
+    throw new Error("Source URL is invalid");
+  }
+
+  if (parsed.protocol !== "postgres:" && parsed.protocol !== "postgresql:") {
+    throw new Error("Source URL must use postgres:// or postgresql://");
+  }
+
+  const host = parsed.hostname.trim();
+  const database = decodeURIComponent(
+    parsed.pathname.replace(/^\//, "").trim(),
+  );
+  const username = decodeURIComponent(parsed.username.trim());
+  const password = decodeURIComponent(parsed.password);
+  const sslMode = parsed.searchParams.get("sslmode")?.trim() ?? "prefer";
+  const unsupportedParams = [
+    "sslrootcert",
+    "sslcert",
+    "sslkey",
+    "sslpassword",
+  ].filter(function hasUnsupportedParam(key) {
+    return parsed.searchParams.has(key);
+  });
+
+  if (!host) {
+    throw new Error("Source URL must include a host");
+  }
+  if (!database) {
+    throw new Error("Source URL must include a database name");
+  }
+  if (!username) {
+    throw new Error("Source URL must include a username");
+  }
+  if (!password) {
+    throw new Error("Source URL must include a password");
+  }
+  if (!isAllowedSslMode(sslMode)) {
+    throw new Error("Source URL uses an unsupported sslmode");
+  }
+
+  const addHostGateway =
+    host === "localhost" || host === "127.0.0.1" || host === "::1";
+
+  return {
+    host,
+    clientHost: addHostGateway ? "host.docker.internal" : host,
+    port: parsed.port.trim().length > 0 ? Number(parsed.port) : 5432,
+    database,
+    username,
+    password,
+    sslMode,
+    addHostGateway,
+    unsupportedParams,
+  };
+}
+
+function getSourceSummaryFromParsedUrl(
+  parsed: ParsedSourceUrl,
+): DatabaseImportSourceSummary {
+  return {
+    ...emptySourceSummary(),
+    host: parsed.host,
+    port: parsed.port,
+    database: parsed.database,
+    username: parsed.username,
+    sslMode: parsed.sslMode,
+  };
+}
+
+function parseDatabaseTargetProviderRef(
+  providerRefJson: string,
+): DatabaseTargetProviderRef {
+  const value = JSON.parse(
+    providerRefJson,
+  ) as Partial<DatabaseTargetProviderRef>;
+
+  if (
+    typeof value.containerName !== "string" ||
+    typeof value.hostPort !== "number" ||
+    typeof value.username !== "string" ||
+    typeof value.password !== "string" ||
+    typeof value.database !== "string" ||
+    typeof value.ssl !== "boolean" ||
+    typeof value.image !== "string" ||
+    typeof value.port !== "number"
+  ) {
+    throw new Error("Invalid database target");
+  }
+
+  return {
+    containerName: value.containerName,
+    hostPort: value.hostPort,
+    username: value.username,
+    password: value.password,
+    database: value.database,
+    ssl: value.ssl,
+    image: value.image,
+    port: value.port,
+  };
+}
+
+function getEstimatedDowntimeMinutes(input: {
+  sizeBytes: number;
+  tableCount: number;
+}): number {
+  const sizeGb = input.sizeBytes / (1024 * 1024 * 1024);
+  const minutes = Math.ceil(sizeGb * 4 + input.tableCount / 200 + 2);
+  return Math.max(2, minutes);
+}
+
+function parseVersionMajor(version: string | null): number | null {
+  if (!version) {
+    return null;
+  }
+  const match = version.match(/^(\d+)/);
+  if (!match) {
+    return null;
+  }
+  return Number(match[1]);
+}
+
+function getSourceImageFromSummary(
+  sourceSummary: DatabaseImportSourceSummary,
+): string {
+  return getPostgresImageForVersion(
+    parseVersionMajor(sourceSummary.serverVersion),
+  );
+}
+
+function getWriteActivityLabel(
+  activeWriteConnectionCount: number,
+): DatabaseImportWriteActivity {
+  return activeWriteConnectionCount > 0 ? "active" : "quiet";
+}
+
+function getImportProgressStepForRestoreLine(line: string): string | null {
+  const normalized = line.toLowerCase();
+  if (
+    normalized.includes("creating schema") ||
+    normalized.includes("creating table") ||
+    normalized.includes("creating sequence") ||
+    normalized.includes("creating function") ||
+    normalized.includes("creating type")
+  ) {
+    return "schema";
+  }
+  if (
+    normalized.includes("processing data for table") ||
+    normalized.includes("copying") ||
+    normalized.includes("copy ")
+  ) {
+    return "data";
+  }
+  if (
+    normalized.includes("creating index") ||
+    normalized.includes("creating constraint") ||
+    normalized.includes("creating trigger")
+  ) {
+    return "indexes";
+  }
+  return null;
+}
+
+function truncateLogText(value: string): string {
+  if (value.length <= IMPORT_LOG_LIMIT) {
+    return value;
+  }
+  return value.slice(value.length - IMPORT_LOG_LIMIT);
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise(function wait(resolve) {
+    setTimeout(resolve, ms);
+  });
+}
+
+function buildSourceDockerArgs(
+  parsed: ParsedSourceUrl,
+  clientArgs: string[],
+  image: string,
+): string[] {
+  const args = ["run", "--rm"];
+
+  if (parsed.addHostGateway) {
+    args.push("--add-host", "host.docker.internal:host-gateway");
+  }
+
+  args.push(
+    "-e",
+    `PGPASSWORD=${parsed.password}`,
+    "-e",
+    `PGSSLMODE=${parsed.sslMode}`,
+    "-e",
+    "PGCONNECT_TIMEOUT=10",
+    "-e",
+    "PGAPPNAME=frost-import",
+    image,
+    ...clientArgs,
+  );
+
+  return args;
+}
+
+function buildSourcePsqlArgs(
+  parsed: ParsedSourceUrl,
+  sql: string,
+  image = getDefaultPostgresImage(),
+): string[] {
+  return buildSourceDockerArgs(
+    parsed,
+    [
+      "psql",
+      "-X",
+      "-v",
+      "ON_ERROR_STOP=1",
+      "-h",
+      parsed.clientHost,
+      "-p",
+      String(parsed.port),
+      "-U",
+      parsed.username,
+      "-d",
+      parsed.database,
+      "-t",
+      "-A",
+      "-c",
+      sql,
+    ],
+    image,
+  );
+}
+
+function buildSourcePgDumpArgs(
+  parsed: ParsedSourceUrl,
+  image: string,
+): string[] {
+  return buildSourceDockerArgs(
+    parsed,
+    [
+      "pg_dump",
+      "-h",
+      parsed.clientHost,
+      "-p",
+      String(parsed.port),
+      "-U",
+      parsed.username,
+      "-d",
+      parsed.database,
+      "-Fc",
+      "--no-owner",
+      "--no-privileges",
+      "--verbose",
+    ],
+    image,
+  );
+}
+
+function buildSourcePgDumpPreflightArgs(
+  parsed: ParsedSourceUrl,
+  image: string,
+): string[] {
+  return buildSourceDockerArgs(
+    parsed,
+    [
+      "pg_dump",
+      "-h",
+      parsed.clientHost,
+      "-p",
+      String(parsed.port),
+      "-U",
+      parsed.username,
+      "-d",
+      parsed.database,
+      "--schema-only",
+      "--no-owner",
+      "--no-privileges",
+      "-f",
+      "/dev/null",
+    ],
+    image,
+  );
+}
+
+function buildTargetPsqlArgs(
+  providerRef: DatabaseTargetProviderRef,
+  database: string,
+  sql: string,
+): string[] {
+  return [
+    "exec",
+    "-e",
+    `PGPASSWORD=${providerRef.password}`,
+    providerRef.containerName,
+    "psql",
+    "-X",
+    "-v",
+    "ON_ERROR_STOP=1",
+    "-h",
+    "127.0.0.1",
+    "-U",
+    providerRef.username,
+    "-d",
+    database,
+    "-t",
+    "-A",
+    "-c",
+    sql,
+  ];
+}
+
+function buildTargetPgRestoreArgs(
+  providerRef: DatabaseTargetProviderRef,
+  remoteDumpPath: string,
+): string[] {
+  return [
+    "exec",
+    "-e",
+    `PGPASSWORD=${providerRef.password}`,
+    providerRef.containerName,
+    "pg_restore",
+    "-h",
+    "127.0.0.1",
+    "-U",
+    providerRef.username,
+    "-d",
+    providerRef.database,
+    "--clean",
+    "--if-exists",
+    "--no-owner",
+    "--no-privileges",
+    "--verbose",
+    remoteDumpPath,
+  ];
+}
+
+function quoteIdentifier(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function buildQualifiedName(schema: string, name: string): string {
+  return `${quoteIdentifier(schema)}.${quoteIdentifier(name)}`;
+}
+
+function buildTableKey(schema: string, name: string): string {
+  return `${schema}.${name}`;
+}
+
+async function runCommand(
+  args: string[],
+  options?: {
+    stdoutFilePath?: string;
+    onStdoutLine?: (line: string) => void;
+    onStderrLine?: (line: string) => void;
+  },
+): Promise<ImportCommandResult> {
+  return await new Promise(function runCommandPromise(resolve, reject) {
+    const child = spawn("docker", args, {
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    const stdoutFileStream = options?.stdoutFilePath
+      ? createWriteStream(options.stdoutFilePath)
+      : null;
+
+    const stdoutReader = createInterface({
+      input: child.stdout,
+    });
+    stdoutReader.on("line", function onStdoutLine(line) {
+      if (options?.onStdoutLine) {
+        options.onStdoutLine(line);
+      }
+    });
+
+    const stderrReader = createInterface({
+      input: child.stderr,
+    });
+    stderrReader.on("line", function onStderrLine(line) {
+      if (options?.onStderrLine) {
+        options.onStderrLine(line);
+      }
+    });
+
+    child.stdout.on("data", function onStdoutData(chunk) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stdoutChunks.push(buffer);
+      if (stdoutFileStream) {
+        stdoutFileStream.write(buffer);
+      }
+    });
+
+    child.stderr.on("data", function onStderrData(chunk) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      stderrChunks.push(buffer);
+    });
+
+    child.on("error", function onError(error) {
+      stdoutReader.close();
+      stderrReader.close();
+      if (stdoutFileStream) {
+        stdoutFileStream.end();
+      }
+      reject(error);
+    });
+
+    child.on("close", function onClose(code) {
+      stdoutReader.close();
+      stderrReader.close();
+      const finalize = function finalize(): void {
+        const stdout = Buffer.concat(stdoutChunks).toString("utf8").trim();
+        const stderr = Buffer.concat(stderrChunks).toString("utf8").trim();
+        if (code === 0) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(new Error(stderr || stdout || "command failed"));
+      };
+
+      if (stdoutFileStream) {
+        stdoutFileStream.end(finalize);
+        return;
+      }
+
+      finalize();
+    });
+  });
+}
+
+function createJobLogger(jobId: string): {
+  appendLine: (line: string) => void;
+  appendBlock: (value: string) => Promise<void>;
+  flush: () => Promise<void>;
+} {
+  let buffer: string[] = [];
+  let flushChain = Promise.resolve();
+
+  function queueFlush(force: boolean): void {
+    if (!force && buffer.length < 20) {
+      return;
+    }
+
+    const lines = buffer;
+    buffer = [];
+
+    if (lines.length === 0) {
+      return;
+    }
+
+    flushChain = flushChain.then(function flushBufferedLines() {
+      return appendImportLog(jobId, lines.join("\n"));
+    });
+  }
+
+  return {
+    appendLine: function appendLine(line: string): void {
+      const trimmed = line.trim();
+      if (!trimmed) {
+        return;
+      }
+      buffer.push(trimmed);
+      queueFlush(false);
+    },
+    appendBlock: async function appendBlock(value: string): Promise<void> {
+      const trimmed = value.trim();
+      if (!trimmed) {
+        return;
+      }
+      buffer.push(trimmed);
+      queueFlush(true);
+      await flushChain;
+    },
+    flush: async function flush(): Promise<void> {
+      queueFlush(true);
+      await flushChain;
+    },
+  };
+}
+
+async function getImportJobRow(jobId: string): Promise<DatabaseImportRow> {
+  const row = await db
+    .selectFrom("databaseImportJobs")
+    .selectAll()
+    .where("id", "=", jobId)
+    .executeTakeFirst();
+
+  if (!row) {
+    throw new Error("Import job not found");
+  }
+
+  return row;
+}
+
+async function getImportTargetConnection(
+  databaseId: string | null,
+): Promise<DatabaseImportTargetConnection | null> {
+  if (!databaseId) {
+    return null;
+  }
+
+  const [database, target] = await Promise.all([
+    db
+      .selectFrom("databases")
+      .selectAll()
+      .where("id", "=", databaseId)
+      .executeTakeFirst(),
+    db
+      .selectFrom("databaseTargets")
+      .selectAll()
+      .where("databaseId", "=", databaseId)
+      .where("name", "=", "main")
+      .executeTakeFirst(),
+  ]);
+
+  if (!database || !target) {
+    return null;
+  }
+
+  const providerRef = parseDatabaseTargetProviderRef(target.providerRefJson);
+
+  return {
+    databaseId,
+    targetId: target.id,
+    internalHost: getDatabaseBranchInternalHost(database.name, target.hostname),
+    hostPort: providerRef.hostPort,
+    username: providerRef.username,
+    password: providerRef.password,
+    database: providerRef.database,
+    ssl: providerRef.ssl,
+  };
+}
+
+async function toJobView(
+  row: DatabaseImportRow,
+): Promise<DatabaseImportJobView> {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    databaseId: row.databaseId,
+    targetName: row.targetName,
+    engine: row.engine,
+    strategy: row.strategy,
+    stage: row.stage,
+    progressStep: row.progressStep,
+    sourceSummary: safeJsonParse<DatabaseImportSourceSummary>(
+      row.sourceSummaryJson,
+      emptySourceSummary(),
+    ),
+    checkResults: safeJsonParse<DatabaseImportCheckResult[]>(
+      row.checkResultsJson,
+      [],
+    ),
+    verifyResult: safeJsonParse<DatabaseImportVerifyResult>(
+      row.verifyResultJson,
+      emptyVerifyResult(),
+    ),
+    logText: row.logText,
+    errorMessage: row.errorMessage,
+    cutoverConfirmedAt: row.cutoverConfirmedAt,
+    completedAt: row.completedAt,
+    failedAt: row.failedAt,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+    targetConnection: await getImportTargetConnection(row.databaseId),
+  };
+}
+
+async function appendImportLog(jobId: string, text: string): Promise<void> {
+  const row = await getImportJobRow(jobId);
+  const trimmed = text.trim();
+  if (!trimmed) {
+    return;
+  }
+
+  const nextLog = truncateLogText(
+    row.logText.length > 0 ? `${row.logText}\n${trimmed}` : trimmed,
+  );
+
+  await db
+    .updateTable("databaseImportJobs")
+    .set({
+      logText: nextLog,
+      updatedAt: Date.now(),
+    })
+    .where("id", "=", jobId)
+    .execute();
+}
+
+async function updateImportJob(
+  jobId: string,
+  updates: DatabaseImportJobUpdate,
+): Promise<void> {
+  await db
+    .updateTable("databaseImportJobs")
+    .set({
+      ...updates,
+      updatedAt: Date.now(),
+    })
+    .where("id", "=", jobId)
+    .execute();
+}
+
+async function markImportFailed(jobId: string, error: unknown): Promise<void> {
+  const message = error instanceof Error ? error.message : String(error);
+
+  await appendImportLog(jobId, `ERROR: ${message}`);
+  await updateImportJob(jobId, {
+    stage: "failed",
+    progressStep: null,
+    errorMessage: message,
+    failedAt: Date.now(),
+  });
+}
+
+async function getSourceUrlForJob(jobId: string): Promise<string> {
+  const row = await getImportJobRow(jobId);
+  if (!row.sourceUrlEncrypted) {
+    throw new Error("Source credentials are no longer available for this job");
+  }
+  return decrypt(row.sourceUrlEncrypted);
+}
+
+async function getDatabaseForImportJob(
+  jobId: string,
+): Promise<Selectable<Databases>> {
+  const row = await getImportJobRow(jobId);
+  if (!row.databaseId) {
+    throw new Error("Import target has not been created");
+  }
+
+  const database = await db
+    .selectFrom("databases")
+    .selectAll()
+    .where("id", "=", row.databaseId)
+    .executeTakeFirst();
+
+  if (!database) {
+    throw new Error("Target database not found");
+  }
+
+  return database;
+}
+
+async function getMainTargetForDatabase(
+  databaseId: string,
+): Promise<Selectable<DatabaseTargets>> {
+  const target = await db
+    .selectFrom("databaseTargets")
+    .selectAll()
+    .where("databaseId", "=", databaseId)
+    .where("name", "=", "main")
+    .executeTakeFirst();
+
+  if (!target) {
+    throw new Error("Target database branch not found");
+  }
+
+  return target;
+}
+
+async function ensureMainTargetIsRunning(
+  databaseId: string,
+): Promise<DatabaseTargetProviderRef> {
+  let target = await getMainTargetForDatabase(databaseId);
+
+  if (target.lifecycleStatus !== "active") {
+    await startDatabaseTarget({
+      databaseId,
+      targetId: target.id,
+    });
+    target = await getMainTargetForDatabase(databaseId);
+  }
+
+  const providerRef = parseDatabaseTargetProviderRef(target.providerRefJson);
+  await waitForTargetReady(providerRef);
+  return providerRef;
+}
+
+async function waitForTargetReady(
+  providerRef: DatabaseTargetProviderRef,
+): Promise<void> {
+  for (let attempt = 1; attempt <= TARGET_READY_MAX_ATTEMPTS; attempt += 1) {
+    try {
+      await runCommand([
+        "exec",
+        "-e",
+        `PGPASSWORD=${providerRef.password}`,
+        providerRef.containerName,
+        "pg_isready",
+        "-h",
+        "127.0.0.1",
+        "-U",
+        providerRef.username,
+        "-d",
+        providerRef.database,
+      ]);
+      return;
+    } catch {
+      if (attempt >= TARGET_READY_MAX_ATTEMPTS) {
+        break;
+      }
+      await sleep(TARGET_READY_DELAY_MS);
+    }
+  }
+
+  throw new Error("Target database did not become ready");
+}
+
+async function querySourceJson<T>(
+  parsed: ParsedSourceUrl,
+  sql: string,
+  image = getDefaultPostgresImage(),
+): Promise<T> {
+  const result = await runCommand(buildSourcePsqlArgs(parsed, sql, image));
+
+  if (!result.stdout) {
+    throw new Error("Source query returned no data");
+  }
+
+  return JSON.parse(result.stdout) as T;
+}
+
+async function queryTargetJson<T>(
+  providerRef: DatabaseTargetProviderRef,
+  database: string,
+  sql: string,
+): Promise<T> {
+  const result = await runCommand(
+    buildTargetPsqlArgs(providerRef, database, sql),
+  );
+
+  if (!result.stdout) {
+    throw new Error("Target query returned no data");
+  }
+
+  return JSON.parse(result.stdout) as T;
+}
+
+async function listSupportedExtensions(image: string): Promise<Set<string>> {
+  const existingPromise = supportedExtensionsPromises.get(image);
+  if (existingPromise) {
+    return await existingPromise;
+  }
+
+  const nextPromise = (async function resolveSupportedExtensions() {
+    const result = await runCommand([
+      "run",
+      "--rm",
+      image,
+      "sh",
+      "-lc",
+      'for f in /usr/local/share/postgresql/extension/*.control; do basename "$f" .control; done | sort',
+    ]);
+
+    const extensionNames = result.stdout
+      .split("\n")
+      .map(function trimLine(line) {
+        return line.trim();
+      })
+      .filter(function hasValue(line) {
+        return line.length > 0;
+      });
+
+    return new Set(extensionNames);
+  })();
+
+  supportedExtensionsPromises.set(image, nextPromise);
+  return await nextPromise;
+}
+
+async function buildPreflight(input: {
+  projectId: string;
+  targetName: string;
+  sourceUrl: string;
+}): Promise<{
+  parsed: ParsedSourceUrl;
+  sourceSummary: DatabaseImportSourceSummary;
+  checkResults: DatabaseImportCheckResult[];
+}> {
+  const parsed = parseSourceUrl(input.sourceUrl);
+  const sourceSummary = getSourceSummaryFromParsedUrl(parsed);
+  const checkResults: DatabaseImportCheckResult[] = [];
+
+  if (parsed.unsupportedParams.length > 0) {
+    checkResults.push({
+      key: "ssl-files",
+      label: "SSL config",
+      status: "blocked",
+      message: `Unsupported SSL params: ${parsed.unsupportedParams.join(", ")}`,
+    });
+
+    return {
+      parsed,
+      sourceSummary,
+      checkResults,
+    };
+  }
+
+  const existingDatabase = await db
+    .selectFrom("databases")
+    .select("id")
+    .where("projectId", "=", input.projectId)
+    .where("name", "=", input.targetName)
+    .executeTakeFirst();
+
+  checkResults.push({
+    key: "target-name",
+    label: "Target name",
+    status: existingDatabase ? "blocked" : "ok",
+    message: existingDatabase
+      ? "A database with this name already exists in Frost"
+      : "Target name is available",
+  });
+
+  try {
+    const summary = await querySourceJson<{
+      serverVersion: string;
+      database: string;
+      owner: string | null;
+      currentUser: string | null;
+      sizeBytes: number;
+      tableCount: number;
+      activeConnectionCount: number;
+      longRunningConnectionCount: number;
+      activeWriteConnectionCount: number;
+    }>(
+      parsed,
+      `
+        SELECT json_build_object(
+          'serverVersion', current_setting('server_version'),
+          'database', current_database(),
+          'owner', (
+            SELECT pg_catalog.pg_get_userbyid(datdba)
+            FROM pg_database
+            WHERE datname = current_database()
+          ),
+          'currentUser', current_user,
+          'sizeBytes', pg_database_size(current_database()),
+          'tableCount', (
+            SELECT count(*)
+            FROM information_schema.tables
+            WHERE table_schema NOT IN ('pg_catalog', 'information_schema')
+              AND table_type = 'BASE TABLE'
+          ),
+          'activeConnectionCount', (
+            SELECT count(*)
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+          ),
+          'longRunningConnectionCount', (
+            SELECT count(*)
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND now() - coalesce(xact_start, query_start, backend_start) > interval '5 minutes'
+          ),
+          'activeWriteConnectionCount', (
+            SELECT count(*)
+            FROM pg_stat_activity
+            WHERE datname = current_database()
+              AND pid <> pg_backend_pid()
+              AND state = 'active'
+              AND query ~* '^(insert|update|delete|copy|alter|create|drop|truncate)'
+          )
+        )::text;
+      `,
+    );
+
+    const extensionNames = await querySourceJson<string[]>(
+      parsed,
+      `
+        SELECT coalesce(json_agg(extname ORDER BY extname), '[]'::json)::text
+        FROM pg_extension;
+      `,
+    );
+
+    sourceSummary.serverVersion = summary.serverVersion;
+    sourceSummary.database = summary.database;
+    sourceSummary.owner = summary.owner;
+    sourceSummary.currentUser = summary.currentUser;
+    sourceSummary.sizeBytes = summary.sizeBytes;
+    sourceSummary.tableCount = summary.tableCount;
+    sourceSummary.activeConnectionCount = summary.activeConnectionCount;
+    sourceSummary.longRunningConnectionCount =
+      summary.longRunningConnectionCount;
+    sourceSummary.activeWriteConnectionCount =
+      summary.activeWriteConnectionCount;
+    sourceSummary.writeActivity = getWriteActivityLabel(
+      summary.activeWriteConnectionCount,
+    );
+    sourceSummary.extensionNames = extensionNames;
+    sourceSummary.estimatedDowntimeMinutes = getEstimatedDowntimeMinutes({
+      sizeBytes: summary.sizeBytes,
+      tableCount: summary.tableCount,
+    });
+
+    checkResults.push({
+      key: "connectivity",
+      label: "Connectivity",
+      status: "ok",
+      message: "Frost can reach and read the source database",
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Failed to connect to source";
+    checkResults.push({
+      key: "connectivity",
+      label: "Connectivity",
+      status: "blocked",
+      message,
+    });
+
+    return {
+      parsed,
+      sourceSummary,
+      checkResults,
+    };
+  }
+
+  const versionMajor = parseVersionMajor(sourceSummary.serverVersion);
+  const sourceImage = getPostgresImageForVersion(versionMajor);
+  checkResults.push({
+    key: "version",
+    label: "Postgres version",
+    status:
+      versionMajor !== null && versionMajor >= PREVIEW_TARGET_VERSION_MIN
+        ? "ok"
+        : "blocked",
+    message:
+      versionMajor !== null && versionMajor >= PREVIEW_TARGET_VERSION_MIN
+        ? `Postgres ${sourceSummary.serverVersion} is supported`
+        : `Postgres ${sourceSummary.serverVersion ?? "unknown"} is not supported`,
+  });
+
+  try {
+    await runCommand(buildSourcePgDumpPreflightArgs(parsed, sourceImage));
+    checkResults.push({
+      key: "dump-access",
+      label: "Dump access",
+      status: "ok",
+      message: "Source credentials can run pg_dump",
+    });
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "pg_dump failed against source";
+    checkResults.push({
+      key: "dump-access",
+      label: "Dump access",
+      status: "blocked",
+      message,
+    });
+  }
+
+  const supportedExtensions = await listSupportedExtensions(sourceImage);
+  const unsupportedExtensions = sourceSummary.extensionNames.filter(
+    function isUnsupported(extensionName) {
+      if (extensionName === "plpgsql") {
+        return false;
+      }
+      return !supportedExtensions.has(extensionName);
+    },
+  );
+  sourceSummary.unsupportedExtensions = unsupportedExtensions;
+
+  checkResults.push({
+    key: "extensions",
+    label: "Extensions",
+    status: unsupportedExtensions.length === 0 ? "ok" : "blocked",
+    message:
+      unsupportedExtensions.length === 0
+        ? "Source extensions are available in Frost"
+        : `Unsupported extensions: ${unsupportedExtensions.join(", ")}`,
+  });
+
+  checkResults.push({
+    key: "activity",
+    label: "Write activity",
+    status:
+      (sourceSummary.activeWriteConnectionCount ?? 0) > 0 ? "warning" : "ok",
+    message:
+      (sourceSummary.activeWriteConnectionCount ?? 0) > 0
+        ? `${sourceSummary.activeWriteConnectionCount ?? 0} active write connection(s) detected`
+        : "No active write connections detected",
+  });
+
+  checkResults.push({
+    key: "long-running",
+    label: "Long-running connections",
+    status:
+      (sourceSummary.longRunningConnectionCount ?? 0) > 0 ? "warning" : "ok",
+    message:
+      (sourceSummary.longRunningConnectionCount ?? 0) > 0
+        ? `${sourceSummary.longRunningConnectionCount ?? 0} long-running connection(s) detected`
+        : "No long-running connections detected",
+  });
+
+  return {
+    parsed,
+    sourceSummary,
+    checkResults,
+  };
+}
+
+function hasBlockedChecks(checkResults: DatabaseImportCheckResult[]): boolean {
+  return checkResults.some(function hasBlockedCheck(checkResult) {
+    return checkResult.status === "blocked";
+  });
+}
+
+export async function createDatabaseImportJob(input: {
+  projectId: string;
+  targetName: string;
+  sourceUrl: string;
+}): Promise<DatabaseImportJobView> {
+  const targetName = input.targetName.trim();
+  if (!targetName) {
+    throw new Error("Target name is required");
+  }
+
+  const now = Date.now();
+  const jobId = newDatabaseImportJobId();
+  const preflight = await buildPreflight({
+    projectId: input.projectId,
+    targetName,
+    sourceUrl: input.sourceUrl,
+  });
+  const stage: DatabaseImportStage = hasBlockedChecks(preflight.checkResults)
+    ? "failed"
+    : "preflight";
+  const errorMessage = stage === "failed" ? "Preflight checks failed" : null;
+
+  await db
+    .insertInto("databaseImportJobs")
+    .values({
+      id: jobId,
+      projectId: input.projectId,
+      databaseId: null,
+      targetName,
+      engine: "postgres",
+      strategy: "dump-restore",
+      sourceUrlEncrypted: encrypt(input.sourceUrl),
+      sourceHost: preflight.parsed.host,
+      sourcePort: preflight.parsed.port,
+      sourceDatabase: preflight.parsed.database,
+      sourceUsername: preflight.parsed.username,
+      sourceSslMode: preflight.parsed.sslMode,
+      stage,
+      progressStep: null,
+      sourceSummaryJson: JSON.stringify(preflight.sourceSummary),
+      checkResultsJson: JSON.stringify(preflight.checkResults),
+      verifyResultJson: JSON.stringify(emptyVerifyResult()),
+      logText:
+        stage === "failed"
+          ? "Preflight failed. Fix the blocked checks and try again."
+          : "Preflight passed. Create the Frost target to continue.",
+      errorMessage,
+      cutoverConfirmedAt: null,
+      completedAt: null,
+      failedAt: stage === "failed" ? now : null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    .execute();
+
+  return await getDatabaseImportJob(jobId);
+}
+
+export async function getDatabaseImportJob(
+  jobId: string,
+): Promise<DatabaseImportJobView> {
+  const row = await getImportJobRow(jobId);
+  return await toJobView(row);
+}
+
+export async function listDatabaseImportJobs(input: {
+  databaseId: string;
+}): Promise<DatabaseImportJobView[]> {
+  const rows = await db
+    .selectFrom("databaseImportJobs")
+    .selectAll()
+    .where("databaseId", "=", input.databaseId)
+    .orderBy("createdAt", "desc")
+    .execute();
+
+  return await Promise.all(
+    rows.map(function mapRow(row) {
+      return toJobView(row);
+    }),
+  );
+}
+
+export async function createDatabaseImportTarget(
+  jobId: string,
+): Promise<DatabaseImportJobView> {
+  const job = await getImportJobRow(jobId);
+  const sourceSummary = safeJsonParse<DatabaseImportSourceSummary>(
+    job.sourceSummaryJson,
+    emptySourceSummary(),
+  );
+
+  if (job.stage !== "preflight" && job.stage !== "failed") {
+    if (job.databaseId) {
+      return await toJobView(job);
+    }
+    throw new Error("Import target cannot be created from the current step");
+  }
+
+  if (hasBlockedChecks(safeJsonParse(job.checkResultsJson, []))) {
+    throw new Error("Fix blocked checks before creating the target");
+  }
+
+  if (job.databaseId) {
+    return await getDatabaseImportJob(jobId);
+  }
+
+  await updateImportJob(jobId, {
+    stage: "target",
+    progressStep: "create-target",
+    errorMessage: null,
+    failedAt: null,
+  });
+
+  try {
+    const created = await createDatabase({
+      projectId: job.projectId,
+      name: job.targetName,
+      engine: "postgres",
+      image: getSourceImageFromSummary(sourceSummary),
+    });
+
+    await appendImportLog(
+      jobId,
+      `Created Frost target database ${created.database.name}.`,
+    );
+    await updateImportJob(jobId, {
+      databaseId: created.database.id,
+      stage: "target",
+      progressStep: null,
+      errorMessage: null,
+    });
+  } catch (error) {
+    await markImportFailed(jobId, error);
+  }
+
+  return await getDatabaseImportJob(jobId);
+}
+
+async function exportSourceDump(input: {
+  parsed: ParsedSourceUrl;
+  sourceImage: string;
+  dumpFilePath: string;
+  logger: ReturnType<typeof createJobLogger>;
+}): Promise<void> {
+  await runCommand(buildSourcePgDumpArgs(input.parsed, input.sourceImage), {
+    stdoutFilePath: input.dumpFilePath,
+    onStderrLine: function onStderrLine(line) {
+      input.logger.appendLine(line);
+    },
+  });
+}
+
+async function copyFileToTargetContainer(input: {
+  providerRef: DatabaseTargetProviderRef;
+  localFilePath: string;
+  remoteFilePath: string;
+}): Promise<void> {
+  await runCommand([
+    "cp",
+    input.localFilePath,
+    `${input.providerRef.containerName}:${input.remoteFilePath}`,
+  ]);
+}
+
+async function removeRemoteFile(input: {
+  providerRef: DatabaseTargetProviderRef;
+  remoteFilePath: string;
+}): Promise<void> {
+  await runCommand([
+    "exec",
+    input.providerRef.containerName,
+    "rm",
+    "-f",
+    input.remoteFilePath,
+  ]).catch(function ignore() {});
+}
+
+async function restoreDumpIntoTarget(input: {
+  providerRef: DatabaseTargetProviderRef;
+  dumpFilePath: string;
+  logger: ReturnType<typeof createJobLogger>;
+  onStep: (step: string) => Promise<void>;
+}): Promise<void> {
+  const remoteDumpPath = `/tmp/frost-import-${Date.now()}.pgdump`;
+
+  try {
+    await runCommand(
+      buildTargetPsqlArgs(
+        input.providerRef,
+        "postgres",
+        `DROP DATABASE IF EXISTS ${quoteIdentifier(input.providerRef.database)};`,
+      ),
+    );
+    await runCommand(
+      buildTargetPsqlArgs(
+        input.providerRef,
+        "postgres",
+        `CREATE DATABASE ${quoteIdentifier(input.providerRef.database)};`,
+      ),
+    );
+
+    await copyFileToTargetContainer({
+      providerRef: input.providerRef,
+      localFilePath: input.dumpFilePath,
+      remoteFilePath: remoteDumpPath,
+    });
+
+    let currentStep = "schema";
+    await input.onStep(currentStep);
+
+    await runCommand(
+      buildTargetPgRestoreArgs(input.providerRef, remoteDumpPath),
+      {
+        onStderrLine: function onStderrLine(line) {
+          input.logger.appendLine(line);
+          const nextStep = getImportProgressStepForRestoreLine(line);
+          if (nextStep && nextStep !== currentStep) {
+            currentStep = nextStep;
+            void input.onStep(nextStep);
+          }
+        },
+      },
+    );
+
+    await input.onStep("finalize");
+  } finally {
+    await removeRemoteFile({
+      providerRef: input.providerRef,
+      remoteFilePath: remoteDumpPath,
+    });
+  }
+}
+
+async function listUserTablesFromSource(
+  parsed: ParsedSourceUrl,
+  image: string,
+): Promise<Array<{ schemaName: string; tableName: string }>> {
+  return await querySourceJson<
+    Array<{ schemaName: string; tableName: string }>
+  >(
+    parsed,
+    `
+      SELECT coalesce(
+        json_agg(
+          json_build_object(
+            'schemaName', table_schema,
+            'tableName', table_name
+          )
+          ORDER BY table_schema, table_name
+        ),
+        '[]'::json
+      )::text
+      FROM information_schema.tables
+      WHERE table_type = 'BASE TABLE'
+        AND table_schema NOT IN ('pg_catalog', 'information_schema');
+    `,
+    image,
+  );
+}
+
+async function listUserTablesFromTarget(
+  providerRef: DatabaseTargetProviderRef,
+): Promise<Array<{ schemaName: string; tableName: string }>> {
+  return await queryTargetJson<
+    Array<{ schemaName: string; tableName: string }>
+  >(
+    providerRef,
+    providerRef.database,
+    `
+      SELECT coalesce(
+        json_agg(
+          json_build_object(
+            'schemaName', table_schema,
+            'tableName', table_name
+          )
+          ORDER BY table_schema, table_name
+        ),
+        '[]'::json
+      )::text
+      FROM information_schema.tables
+      WHERE table_type = 'BASE TABLE'
+        AND table_schema NOT IN ('pg_catalog', 'information_schema');
+    `,
+  );
+}
+
+async function getSourceTableCount(
+  parsed: ParsedSourceUrl,
+  schemaName: string,
+  tableName: string,
+  image: string,
+): Promise<number> {
+  const result = await runCommand(
+    buildSourcePsqlArgs(
+      parsed,
+      `SELECT count(*)::text FROM ${buildQualifiedName(schemaName, tableName)};`,
+      image,
+    ),
+  );
+  return Number(result.stdout || "0");
+}
+
+async function getTargetTableCount(
+  providerRef: DatabaseTargetProviderRef,
+  schemaName: string,
+  tableName: string,
+): Promise<number> {
+  const result = await runCommand(
+    buildTargetPsqlArgs(
+      providerRef,
+      providerRef.database,
+      `SELECT count(*)::text FROM ${buildQualifiedName(schemaName, tableName)};`,
+    ),
+  );
+  return Number(result.stdout || "0");
+}
+
+async function listSourceSequences(
+  parsed: ParsedSourceUrl,
+  image: string,
+): Promise<Array<{ sequenceKey: string; lastValue: string | null }>> {
+  return await querySourceJson<
+    Array<{ sequenceKey: string; lastValue: string | null }>
+  >(
+    parsed,
+    `
+      SELECT coalesce(
+        json_agg(
+          json_build_object(
+            'sequenceKey', schemaname || '.' || sequencename,
+            'lastValue', last_value::text
+          )
+          ORDER BY schemaname, sequencename
+        ),
+        '[]'::json
+      )::text
+      FROM pg_sequences
+      WHERE schemaname NOT IN ('pg_catalog', 'information_schema');
+    `,
+    image,
+  );
+}
+
+async function listTargetSequences(
+  providerRef: DatabaseTargetProviderRef,
+): Promise<Array<{ sequenceKey: string; lastValue: string | null }>> {
+  return await queryTargetJson<
+    Array<{ sequenceKey: string; lastValue: string | null }>
+  >(
+    providerRef,
+    providerRef.database,
+    `
+      SELECT coalesce(
+        json_agg(
+          json_build_object(
+            'sequenceKey', schemaname || '.' || sequencename,
+            'lastValue', last_value::text
+          )
+          ORDER BY schemaname, sequencename
+        ),
+        '[]'::json
+      )::text
+      FROM pg_sequences
+      WHERE schemaname NOT IN ('pg_catalog', 'information_schema');
+    `,
+  );
+}
+
+async function listTargetExtensions(
+  providerRef: DatabaseTargetProviderRef,
+): Promise<string[]> {
+  return await queryTargetJson<string[]>(
+    providerRef,
+    providerRef.database,
+    `
+      SELECT coalesce(json_agg(extname ORDER BY extname), '[]'::json)::text
+      FROM pg_extension;
+    `,
+  );
+}
+
+function compareStringArrays(
+  left: string[],
+  right: string[],
+): { matches: boolean; missing: string[]; extra: string[] } {
+  const leftSet = new Set(left);
+  const rightSet = new Set(right);
+
+  const missing = left.filter(function filterMissing(value) {
+    return !rightSet.has(value);
+  });
+  const extra = right.filter(function filterExtra(value) {
+    return !leftSet.has(value);
+  });
+
+  return {
+    matches: missing.length === 0 && extra.length === 0,
+    missing,
+    extra,
+  };
+}
+
+function compareSequenceLists(
+  left: Array<{ sequenceKey: string; lastValue: string | null }>,
+  right: Array<{ sequenceKey: string; lastValue: string | null }>,
+): { matches: boolean; mismatches: string[] } {
+  const rightMap = new Map(
+    right.map(function toEntry(item) {
+      return [item.sequenceKey, item.lastValue] as const;
+    }),
+  );
+
+  const mismatches = left
+    .filter(function hasMismatch(item) {
+      return rightMap.get(item.sequenceKey) !== item.lastValue;
+    })
+    .map(function toKey(item) {
+      return item.sequenceKey;
+    });
+
+  return {
+    matches: mismatches.length === 0,
+    mismatches,
+  };
+}
+
+async function verifyImport(
+  jobId: string,
+): Promise<DatabaseImportVerifyResult> {
+  const sourceUrl = await getSourceUrlForJob(jobId);
+  const parsed = parseSourceUrl(sourceUrl);
+  const sourceSummary = safeJsonParse<DatabaseImportSourceSummary>(
+    (await getImportJobRow(jobId)).sourceSummaryJson,
+    emptySourceSummary(),
+  );
+  const sourceImage = getSourceImageFromSummary(sourceSummary);
+  const database = await getDatabaseForImportJob(jobId);
+  const providerRef = await ensureMainTargetIsRunning(database.id);
+  const checks: DatabaseImportVerifyCheck[] = [];
+
+  const sourceTables = await listUserTablesFromSource(parsed, sourceImage);
+  const targetTables = await listUserTablesFromTarget(providerRef);
+  const sourceTableKeys = sourceTables.map(function toKey(table) {
+    return buildTableKey(table.schemaName, table.tableName);
+  });
+  const targetTableKeys = targetTables.map(function toKey(table) {
+    return buildTableKey(table.schemaName, table.tableName);
+  });
+  const tableCompare = compareStringArrays(sourceTableKeys, targetTableKeys);
+
+  checks.push({
+    key: "tables",
+    label: "Tables",
+    status: tableCompare.matches ? "pass" : "failed",
+    message: tableCompare.matches
+      ? `${sourceTableKeys.length} table(s) match`
+      : `Table mismatch. Missing: ${tableCompare.missing.join(", ") || "none"}; extra: ${tableCompare.extra.join(", ") || "none"}`,
+  });
+
+  const rowCountMismatches: string[] = [];
+  if (tableCompare.matches) {
+    for (const table of sourceTables) {
+      const sourceCount = await getSourceTableCount(
+        parsed,
+        table.schemaName,
+        table.tableName,
+        sourceImage,
+      );
+      const targetCount = await getTargetTableCount(
+        providerRef,
+        table.schemaName,
+        table.tableName,
+      );
+      if (sourceCount !== targetCount) {
+        rowCountMismatches.push(
+          `${buildTableKey(table.schemaName, table.tableName)} (${sourceCount} -> ${targetCount})`,
+        );
+      }
+    }
+  }
+
+  checks.push({
+    key: "row-counts",
+    label: "Row counts",
+    status:
+      tableCompare.matches && rowCountMismatches.length === 0
+        ? "pass"
+        : "failed",
+    message: !tableCompare.matches
+      ? "Skipped because table lists do not match"
+      : rowCountMismatches.length === 0
+        ? "All table row counts match"
+        : `Row count mismatch in ${rowCountMismatches.join(", ")}`,
+  });
+
+  const sourceSequences = await listSourceSequences(parsed, sourceImage);
+  const targetSequences = await listTargetSequences(providerRef);
+  const sequenceCompare = compareSequenceLists(
+    sourceSequences,
+    targetSequences,
+  );
+
+  checks.push({
+    key: "sequences",
+    label: "Sequences",
+    status: sequenceCompare.matches ? "pass" : "failed",
+    message: sequenceCompare.matches
+      ? "Sequence positions match"
+      : `Sequence mismatch in ${sequenceCompare.mismatches.join(", ")}`,
+  });
+
+  const targetExtensions = await listTargetExtensions(providerRef);
+  const extensionCompare = compareStringArrays(
+    sourceSummary.extensionNames,
+    targetExtensions,
+  );
+
+  checks.push({
+    key: "extensions",
+    label: "Extensions",
+    status: extensionCompare.matches ? "pass" : "failed",
+    message: extensionCompare.matches
+      ? "Extensions match"
+      : `Extension mismatch. Missing: ${extensionCompare.missing.join(", ") || "none"}; extra: ${extensionCompare.extra.join(", ") || "none"}`,
+  });
+
+  const failedChecks = checks.filter(function isFailed(check) {
+    return check.status === "failed";
+  });
+  const warningChecks = checks.filter(function isWarning(check) {
+    return check.status === "warning";
+  });
+
+  return {
+    status:
+      failedChecks.length > 0
+        ? "failed"
+        : warningChecks.length > 0
+          ? "warning"
+          : "pass",
+    checks,
+    comparedAt: Date.now(),
+  };
+}
+
+export async function runDatabaseImportJob(jobId: string): Promise<void> {
+  const logger = createJobLogger(jobId);
+  const job = await getImportJobRow(jobId);
+  const sourceUrl = await getSourceUrlForJob(jobId);
+  const parsed = parseSourceUrl(sourceUrl);
+  const sourceSummary = safeJsonParse<DatabaseImportSourceSummary>(
+    job.sourceSummaryJson,
+    emptySourceSummary(),
+  );
+  const sourceImage = getSourceImageFromSummary(sourceSummary);
+  const database = await getDatabaseForImportJob(jobId);
+  const providerRef = await ensureMainTargetIsRunning(database.id);
+  const tempDir = await mkdtemp(join(tmpdir(), "frost-import-"));
+  const dumpFilePath = join(tempDir, "source.pgdump");
+
+  try {
+    await logger.appendBlock(
+      `Starting import from ${parsed.host}:${parsed.port}/${parsed.database}.`,
+    );
+    await updateImportJob(jobId, {
+      stage: "importing",
+      progressStep: "export",
+      errorMessage: null,
+      failedAt: null,
+      verifyResultJson: JSON.stringify(emptyVerifyResult()),
+    });
+
+    await exportSourceDump({
+      parsed,
+      sourceImage,
+      dumpFilePath,
+      logger,
+    });
+    await logger.flush();
+
+    await restoreDumpIntoTarget({
+      providerRef,
+      dumpFilePath,
+      logger,
+      onStep: async function onStep(step) {
+        await updateImportJob(jobId, {
+          progressStep: step,
+        });
+      },
+    });
+    await logger.flush();
+
+    await appendImportLog(jobId, "Import finished. Ready to verify.");
+    await updateImportJob(jobId, {
+      stage: "imported",
+      progressStep: null,
+      errorMessage: null,
+    });
+
+    activeVerifyJobs.add(jobId);
+    await runDatabaseImportVerifyJob(jobId);
+  } catch (error) {
+    await logger.flush();
+    await markImportFailed(jobId, error);
+  } finally {
+    activeImportJobs.delete(jobId);
+    await rm(tempDir, { recursive: true, force: true }).catch(
+      function ignore() {},
+    );
+  }
+}
+
+export async function runDatabaseImportVerifyJob(jobId: string): Promise<void> {
+  try {
+    await appendImportLog(jobId, "Starting verification.");
+    await updateImportJob(jobId, {
+      stage: "verifying",
+      progressStep: "tables",
+      errorMessage: null,
+      failedAt: null,
+    });
+
+    const verifyResult = await verifyImport(jobId);
+
+    if (verifyResult.status === "failed") {
+      await appendImportLog(jobId, "Verification failed.");
+      await updateImportJob(jobId, {
+        stage: "failed",
+        progressStep: null,
+        errorMessage: "Verification failed",
+        failedAt: Date.now(),
+        verifyResultJson: JSON.stringify(verifyResult),
+      });
+      return;
+    }
+
+    const now = Date.now();
+    await appendImportLog(jobId, "Verification passed. Import completed.");
+    await updateImportJob(jobId, {
+      stage: "completed",
+      progressStep: null,
+      errorMessage: null,
+      cutoverConfirmedAt: null,
+      completedAt: now,
+      sourceUrlEncrypted: null,
+      verifyResultJson: JSON.stringify(verifyResult),
+    });
+  } catch (error) {
+    await markImportFailed(jobId, error);
+  } finally {
+    activeVerifyJobs.delete(jobId);
+  }
+}
+
+export async function triggerDatabaseImport(
+  jobId: string,
+): Promise<DatabaseImportJobView> {
+  let job = await getImportJobRow(jobId);
+
+  if (!job.databaseId) {
+    const createdTargetJob = await createDatabaseImportTarget(jobId);
+    if (!createdTargetJob.databaseId) {
+      throw new Error(
+        createdTargetJob.errorMessage ?? "Failed to create Frost target",
+      );
+    }
+    job = await getImportJobRow(jobId);
+  }
+  if (activeImportJobs.has(jobId)) {
+    return await getDatabaseImportJob(jobId);
+  }
+  if (job.stage === "verifying") {
+    throw new Error("Verification is already running");
+  }
+
+  activeImportJobs.add(jobId);
+  void runDatabaseImportJob(jobId);
+  return await getDatabaseImportJob(jobId);
+}
+
+export async function triggerDatabaseImportVerify(
+  jobId: string,
+): Promise<DatabaseImportJobView> {
+  const job = await getImportJobRow(jobId);
+
+  if (!job.databaseId) {
+    throw new Error("Create the Frost target before verifying");
+  }
+  if (job.stage !== "imported" && job.stage !== "failed") {
+    if (job.stage === "ready-for-cutover" || job.stage === "completed") {
+      return await toJobView(job);
+    }
+    throw new Error("Run the import before verifying");
+  }
+  if (activeVerifyJobs.has(jobId)) {
+    return await toJobView(job);
+  }
+
+  activeVerifyJobs.add(jobId);
+  void runDatabaseImportVerifyJob(jobId);
+  return await getDatabaseImportJob(jobId);
+}
+
+export async function markDatabaseImportCutover(
+  jobId: string,
+): Promise<DatabaseImportJobView> {
+  const job = await getImportJobRow(jobId);
+
+  if (job.stage !== "ready-for-cutover") {
+    throw new Error("Import is not ready for cutover");
+  }
+
+  const now = Date.now();
+  await appendImportLog(jobId, "Cutover confirmed.");
+  await updateImportJob(jobId, {
+    stage: "completed",
+    progressStep: null,
+    cutoverConfirmedAt: now,
+    completedAt: now,
+    sourceUrlEncrypted: null,
+    errorMessage: null,
+  });
+
+  return await getDatabaseImportJob(jobId);
+}

--- a/apps/app/src/server/databases.ts
+++ b/apps/app/src/server/databases.ts
@@ -28,6 +28,15 @@ import {
   runPostgresBackup,
   testPostgresBackupConnection,
 } from "@/lib/postgres-backup-runner";
+import {
+  createDatabaseImportJob,
+  createDatabaseImportTarget,
+  getDatabaseImportJob,
+  listDatabaseImportJobs,
+  markDatabaseImportCutover,
+  triggerDatabaseImport,
+  triggerDatabaseImportVerify,
+} from "@/lib/postgres-import";
 import { os } from "./orpc";
 
 function toApiError(error: unknown) {
@@ -251,6 +260,72 @@ export const databases = {
       throw toApiError(error);
     }
   }),
+
+  createImportJob: os.databases.createImportJob.handler(async ({ input }) => {
+    try {
+      return await createDatabaseImportJob({
+        projectId: input.projectId,
+        targetName: input.targetName,
+        sourceUrl: input.sourceUrl,
+      });
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  getImportJob: os.databases.getImportJob.handler(async ({ input }) => {
+    try {
+      return await getDatabaseImportJob(input.jobId);
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  listImportJobs: os.databases.listImportJobs.handler(async ({ input }) => {
+    try {
+      return await listDatabaseImportJobs({
+        databaseId: input.databaseId,
+      });
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  createImportTarget: os.databases.createImportTarget.handler(
+    async ({ input }) => {
+      try {
+        return await createDatabaseImportTarget(input.jobId);
+      } catch (error) {
+        throw toApiError(error);
+      }
+    },
+  ),
+
+  runImportJob: os.databases.runImportJob.handler(async ({ input }) => {
+    try {
+      return await triggerDatabaseImport(input.jobId);
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  runImportVerify: os.databases.runImportVerify.handler(async ({ input }) => {
+    try {
+      return await triggerDatabaseImportVerify(input.jobId);
+    } catch (error) {
+      throw toApiError(error);
+    }
+  }),
+
+  markImportCutover: os.databases.markImportCutover.handler(
+    async ({ input }) => {
+      try {
+        return await markDatabaseImportCutover(input.jobId);
+      } catch (error) {
+        throw toApiError(error);
+      }
+    },
+  ),
 
   delete: os.databases.delete.handler(async ({ input }) => {
     try {


### PR DESCRIPTION
## Summary
- add a Postgres import job model and API for preflight, import, and verify
- add a simple import wizard in the database create flow
- auto-create the target, run import, verify, and show completed state in one flow
- match the source Postgres major version for import tools and created target databases

## Testing
- bun run typecheck
- bun run lint
- bun --cwd apps/app test src/lib/postgres-import.integration.test.ts
