### PR TITLE
fix(projects): include databases in health summary

### DIFF
--- a/apps/app/src/app/(workspace)/_components/project-card.tsx
+++ b/apps/app/src/app/(workspace)/_components/project-card.tsx
@@ -1,8 +1,8 @@
 import { GitBranch, Github } from "lucide-react";
 import Link from "next/link";
-import { StatusBadge } from "@/components/status-badge";
-import type { ProjectLatestDeployment } from "@/lib/api";
+import type { ProjectLatestDeployment, ProjectListItem } from "@/lib/api";
 import { ProjectAvatar } from "./project-avatar";
+import { ProjectResourceBadges } from "./project-resource-badges";
 
 function formatTimeAgo(timestamp: number): string {
   const seconds = Math.floor((Date.now() - timestamp) / 1000);
@@ -27,9 +27,7 @@ interface ProjectCardProps {
   runningUrl?: string | null;
   repoUrl?: string | null;
   latestDeployment?: ProjectLatestDeployment | null;
-  serviceCount: number;
-  onlineCount: number;
-  attentionCount: number;
+  resourceSummary: ProjectListItem["resourceSummary"];
 }
 
 export function ProjectCard({
@@ -38,9 +36,7 @@ export function ProjectCard({
   runningUrl,
   repoUrl,
   latestDeployment,
-  serviceCount,
-  onlineCount,
-  attentionCount,
+  resourceSummary,
 }: ProjectCardProps) {
   const repoPath = repoUrl ? extractRepoPath(repoUrl) : null;
 
@@ -59,14 +55,12 @@ export function ProjectCard({
         </div>
       </div>
 
-      {serviceCount > 0 && (
+      {resourceSummary.totalCount > 0 && (
         <div className="mt-3 flex flex-wrap items-center gap-2">
-          <StatusBadge tone={onlineCount > 0 ? "success" : "neutral"}>
-            {onlineCount}/{serviceCount} online
-          </StatusBadge>
-          {attentionCount > 0 && (
-            <StatusBadge tone="warning">{attentionCount} attention</StatusBadge>
-          )}
+          <ProjectResourceBadges
+            resourceSummary={resourceSummary}
+            breakdownClassName="text-xs text-neutral-400"
+          />
         </div>
       )}
 

--- a/apps/app/src/app/(workspace)/_components/project-resource-badges.tsx
+++ b/apps/app/src/app/(workspace)/_components/project-resource-badges.tsx
@@ -1,0 +1,36 @@
+import { StatusBadge } from "@/components/status-badge";
+import type { ProjectListItem } from "@/lib/api";
+import {
+  formatProjectResourceBreakdown,
+  getProjectResourceSummaryTone,
+} from "@/lib/project-resource-summary";
+
+interface ProjectResourceBadgesProps {
+  resourceSummary: ProjectListItem["resourceSummary"];
+  breakdownClassName?: string;
+}
+
+export function ProjectResourceBadges({
+  resourceSummary,
+  breakdownClassName,
+}: ProjectResourceBadgesProps) {
+  if (resourceSummary.totalCount === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      <span className={breakdownClassName}>
+        {formatProjectResourceBreakdown(resourceSummary)}
+      </span>
+      <StatusBadge tone={getProjectResourceSummaryTone(resourceSummary)}>
+        {resourceSummary.onlineCount}/{resourceSummary.totalCount} online
+      </StatusBadge>
+      {resourceSummary.attentionCount > 0 && (
+        <StatusBadge tone="warning">
+          {resourceSummary.attentionCount} attention
+        </StatusBadge>
+      )}
+    </>
+  );
+}

--- a/apps/app/src/app/(workspace)/page.tsx
+++ b/apps/app/src/app/(workspace)/page.tsx
@@ -4,7 +4,6 @@ import { LayoutGrid, List, Plus, Rocket, Search } from "lucide-react";
 import Link from "next/link";
 import { useMemo, useState } from "react";
 import { EmptyState } from "@/components/empty-state";
-import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/skeleton";
@@ -13,6 +12,7 @@ import type { ProjectListItem } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { ProjectAvatar } from "./_components/project-avatar";
 import { ProjectCard } from "./_components/project-card";
+import { ProjectResourceBadges } from "./_components/project-resource-badges";
 
 type ProjectViewMode = "cards" | "list";
 
@@ -20,26 +20,7 @@ interface ProjectListRowProps {
   project: ProjectListItem;
 }
 
-function getProjectStatusCounts(project: ProjectListItem): {
-  serviceCount: number;
-  onlineCount: number;
-  attentionCount: number;
-} {
-  return {
-    serviceCount: project.services.length,
-    onlineCount: project.services.filter(function isOnline(service) {
-      return service.runtimeStatus === "online";
-    }).length,
-    attentionCount: project.services.filter(function hasAttention(service) {
-      return service.attentionStatus !== null;
-    }).length,
-  };
-}
-
 function ProjectListRow({ project }: ProjectListRowProps) {
-  const { serviceCount, onlineCount, attentionCount } =
-    getProjectStatusCounts(project);
-
   return (
     <Link
       href={`/projects/${project.id}`}
@@ -59,15 +40,7 @@ function ProjectListRow({ project }: ProjectListRowProps) {
         </div>
       </div>
       <div className="hidden shrink-0 items-center gap-4 text-sm text-neutral-400 md:flex">
-        <span>
-          {serviceCount} service{serviceCount === 1 ? "" : "s"}
-        </span>
-        <StatusBadge tone={onlineCount > 0 ? "success" : "neutral"}>
-          {onlineCount}/{serviceCount} online
-        </StatusBadge>
-        {attentionCount > 0 && (
-          <StatusBadge tone="warning">{attentionCount} attention</StatusBadge>
-        )}
+        <ProjectResourceBadges resourceSummary={project.resourceSummary} />
       </div>
     </Link>
   );
@@ -160,8 +133,6 @@ export default function Home() {
       return (
         <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
           {filteredProjects.map(function renderProject(project) {
-            const { serviceCount, onlineCount, attentionCount } =
-              getProjectStatusCounts(project);
             return (
               <ProjectCard
                 key={project.id}
@@ -170,9 +141,7 @@ export default function Home() {
                 runningUrl={project.runningUrl}
                 repoUrl={project.repoUrl}
                 latestDeployment={project.latestDeployment}
-                serviceCount={serviceCount}
-                onlineCount={onlineCount}
-                attentionCount={attentionCount}
+                resourceSummary={project.resourceSummary}
               />
             );
           })}

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-content.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-content.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ServiceRuntimeIndicator } from "@/components/service-runtime-indicator";
 import { Badge } from "@/components/ui/badge";
+import type { Service } from "@/lib/api";
 import {
   DATABASE_LOGO_FALLBACK,
   getDatabaseLogoAlt,
@@ -13,6 +15,8 @@ export interface CanvasDatabase {
   name: string;
   engine: "postgres" | "mysql";
   provider: "postgres-docker" | "mysql-docker";
+  runtimeStatus?: Service["runtimeStatus"];
+  attentionStatus?: Service["attentionStatus"];
 }
 
 interface DatabaseContentProps {
@@ -55,9 +59,18 @@ export function DatabaseContent({ database }: DatabaseContentProps) {
           />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="truncate font-medium text-neutral-200">
-            {database.name}
-          </p>
+          <div className="flex items-center justify-between gap-2">
+            <p className="truncate font-medium text-neutral-200">
+              {database.name}
+            </p>
+            {database.runtimeStatus && (
+              <ServiceRuntimeIndicator
+                runtimeStatus={database.runtimeStatus}
+                attentionStatus={database.attentionStatus ?? null}
+                className="shrink-0"
+              />
+            )}
+          </div>
           <p className="truncate text-xs text-neutral-500">
             {getDatabaseSubtitle(database.engine)}
           </p>

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/project-left-menu.tsx
@@ -303,6 +303,8 @@ export function ProjectLeftMenu({
                     iconFallback={DATABASE_LOGO_FALLBACK}
                     name={database.name}
                     subtitle={`${database.engine} · manual`}
+                    runtimeStatus={database.runtimeStatus}
+                    attentionStatus={database.attentionStatus}
                   />
                 );
               })}

--- a/apps/app/src/contracts/databases.ts
+++ b/apps/app/src/contracts/databases.ts
@@ -1,5 +1,9 @@
 import { oc } from "@orpc/contract";
 import { z } from "zod";
+import {
+  serviceAttentionStatusSchema,
+  serviceRuntimeStatusSchema,
+} from "./shared";
 
 const databaseEngineSchema = z.enum(["postgres", "mysql"]);
 const databaseProviderSchema = z.enum(["postgres-docker", "mysql-docker"]);
@@ -38,6 +42,11 @@ export const databaseSchema = z.object({
   engine: databaseEngineSchema,
   provider: databaseProviderSchema,
   createdAt: z.number(),
+});
+
+const databaseListItemSchema = databaseSchema.extend({
+  runtimeStatus: serviceRuntimeStatusSchema,
+  attentionStatus: serviceAttentionStatusSchema,
 });
 
 export const databaseTargetSchema = z.object({
@@ -273,7 +282,7 @@ export const databasesContract = {
   list: oc
     .route({ method: "GET", path: "/projects/{projectId}/databases" })
     .input(z.object({ projectId: z.string() }))
-    .output(z.array(databaseSchema)),
+    .output(z.array(databaseListItemSchema)),
 
   get: oc
     .route({ method: "GET", path: "/databases/{databaseId}" })

--- a/apps/app/src/contracts/projects.ts
+++ b/apps/app/src/contracts/projects.ts
@@ -25,11 +25,20 @@ const projectListServiceSchema = z.object({
   attentionStatus: serviceAttentionStatusSchema,
 });
 
+const projectResourceSummarySchema = z.object({
+  serviceCount: z.number(),
+  databaseCount: z.number(),
+  totalCount: z.number(),
+  onlineCount: z.number(),
+  attentionCount: z.number(),
+});
+
 const projectListItemSchema = projectsSchema.extend({
   servicesCount: z.number(),
   latestDeployment: latestDeploymentSchema.nullable(),
   repoUrl: z.string().nullable(),
   runningUrl: z.string().nullable(),
+  resourceSummary: projectResourceSummarySchema,
   services: z.array(projectListServiceSchema),
 });
 

--- a/apps/app/src/lib/database-runtime-status.test.ts
+++ b/apps/app/src/lib/database-runtime-status.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { getDatabaseRuntimeState } from "./database-runtime-status";
+
+describe("getDatabaseRuntimeState", () => {
+  test("returns online for an active main target", () => {
+    expect(
+      getDatabaseRuntimeState({
+        mainTarget: { lifecycleStatus: "active" },
+        latestDeployment: { status: "running" },
+      }),
+    ).toEqual({
+      runtimeStatus: "online",
+      attentionStatus: null,
+    });
+  });
+
+  test("returns offline for a stopped main target", () => {
+    expect(
+      getDatabaseRuntimeState({
+        mainTarget: { lifecycleStatus: "stopped" },
+        latestDeployment: { status: "stopped" },
+      }),
+    ).toEqual({
+      runtimeStatus: "offline",
+      attentionStatus: null,
+    });
+  });
+
+  test("returns online with attention after a failed deploy on an active target", () => {
+    expect(
+      getDatabaseRuntimeState({
+        mainTarget: { lifecycleStatus: "active" },
+        latestDeployment: { status: "failed" },
+      }),
+    ).toEqual({
+      runtimeStatus: "online",
+      attentionStatus: "last-deploy-failed",
+    });
+  });
+});

--- a/apps/app/src/lib/database-runtime-status.ts
+++ b/apps/app/src/lib/database-runtime-status.ts
@@ -1,0 +1,51 @@
+import type {
+  ServiceAttentionStatus,
+  ServiceRuntimeStatus,
+} from "./service-runtime-status";
+
+interface DatabaseTargetLike {
+  lifecycleStatus: "active" | "stopped" | "expired";
+}
+
+interface DatabaseTargetDeploymentLike {
+  status: "running" | "failed" | "stopped";
+}
+
+interface DatabaseRuntimeInput {
+  mainTarget: DatabaseTargetLike | null;
+  latestDeployment: DatabaseTargetDeploymentLike | null;
+}
+
+interface DatabaseRuntimeState {
+  runtimeStatus: ServiceRuntimeStatus;
+  attentionStatus: ServiceAttentionStatus;
+}
+
+const ONLINE_STATE: DatabaseRuntimeState = {
+  runtimeStatus: "online",
+  attentionStatus: null,
+};
+
+const ONLINE_FAILED_STATE: DatabaseRuntimeState = {
+  runtimeStatus: "online",
+  attentionStatus: "last-deploy-failed",
+};
+
+const OFFLINE_STATE: DatabaseRuntimeState = {
+  runtimeStatus: "offline",
+  attentionStatus: null,
+};
+
+export function getDatabaseRuntimeState(
+  input: DatabaseRuntimeInput,
+): DatabaseRuntimeState {
+  if (input.mainTarget?.lifecycleStatus !== "active") {
+    return OFFLINE_STATE;
+  }
+
+  if (input.latestDeployment?.status === "failed") {
+    return ONLINE_FAILED_STATE;
+  }
+
+  return ONLINE_STATE;
+}

--- a/apps/app/src/lib/database-runtime.ts
+++ b/apps/app/src/lib/database-runtime.ts
@@ -8,6 +8,7 @@ import {
   type DatabaseProvider,
   normalizeDatabaseProvider,
 } from "./database-provider";
+import { getDatabaseRuntimeState } from "./database-runtime-status";
 import {
   startDatabaseTargetGateway,
   stopDatabaseTargetGateway,
@@ -48,6 +49,10 @@ import {
   resolvePostgresStorageMountPath,
   swapPostgresStorageFromStaged,
 } from "./postgres-branching/postgres-branch-runtime";
+import type {
+  ServiceAttentionStatus,
+  ServiceRuntimeStatus,
+} from "./service-runtime-status";
 import { shellEscape } from "./shell-escape";
 import { slugify } from "./slugify";
 
@@ -63,6 +68,11 @@ export type DatabaseTargetDeploymentAction =
   | "start"
   | "stop";
 export type DatabaseTargetDeploymentStatus = "running" | "failed" | "stopped";
+
+export interface DatabaseWithRuntimeState extends Selectable<Databases> {
+  runtimeStatus: ServiceRuntimeStatus;
+  attentionStatus: ServiceAttentionStatus;
+}
 
 interface ProviderRef {
   containerName: string;
@@ -1989,6 +1999,71 @@ export async function listDatabasesByProject(projectId: string) {
     .execute();
 
   return databases.map(normalizeDatabase);
+}
+
+export async function listDatabasesWithRuntimeByProject(
+  projectId: string,
+): Promise<DatabaseWithRuntimeState[]> {
+  const databases = await listDatabasesByProject(projectId);
+
+  if (databases.length === 0) {
+    return [];
+  }
+
+  const databaseIds = databases.map(function getDatabaseId(database) {
+    return database.id;
+  });
+
+  const mainTargets = await db
+    .selectFrom("databaseTargets")
+    .selectAll()
+    .where("databaseId", "in", databaseIds)
+    .where("name", "=", "main")
+    .execute();
+
+  const mainTargetIds = mainTargets.map(function getTargetId(target) {
+    return target.id;
+  });
+
+  const latestDeployments =
+    mainTargetIds.length > 0
+      ? await db
+          .selectFrom("databaseTargetDeployments")
+          .select(["targetId", "status", "createdAt"])
+          .where("targetId", "in", mainTargetIds)
+          .orderBy("createdAt", "desc")
+          .execute()
+      : [];
+
+  const mainTargetByDatabaseId = new Map(
+    mainTargets.map(function getEntry(target) {
+      return [target.databaseId, target] as const;
+    }),
+  );
+  const latestDeploymentByTargetId = new Map();
+
+  for (const deployment of latestDeployments) {
+    if (!latestDeploymentByTargetId.has(deployment.targetId)) {
+      latestDeploymentByTargetId.set(deployment.targetId, deployment);
+    }
+  }
+
+  return databases.map(function mapDatabase(database) {
+    const mainTarget = mainTargetByDatabaseId.get(database.id) ?? null;
+    const latestDeployment = mainTarget
+      ? (latestDeploymentByTargetId.get(mainTarget.id) ?? null)
+      : null;
+    const runtimeState = getDatabaseRuntimeState({
+      mainTarget,
+      latestDeployment,
+    });
+
+    return {
+      ...database,
+      runtimeStatus: runtimeState.runtimeStatus,
+      attentionStatus: runtimeState.attentionStatus,
+    };
+  });
 }
 
 export async function listDatabaseTargets(databaseId: string) {

--- a/apps/app/src/lib/project-resource-summary.test.ts
+++ b/apps/app/src/lib/project-resource-summary.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, test } from "bun:test";
+import {
+  formatProjectResourceBreakdown,
+  getProjectResourceSummary,
+  getProjectResourceSummaryTone,
+} from "./project-resource-summary";
+
+describe("getProjectResourceSummary", () => {
+  test("counts services and databases together", () => {
+    const summary = getProjectResourceSummary({
+      services: [
+        { runtimeStatus: "online", attentionStatus: null },
+        { runtimeStatus: "offline", attentionStatus: null },
+      ],
+      databases: [{ runtimeStatus: "online", attentionStatus: null }],
+    });
+
+    expect(summary).toEqual({
+      serviceCount: 2,
+      databaseCount: 1,
+      totalCount: 3,
+      onlineCount: 2,
+      attentionCount: 0,
+    });
+  });
+});
+
+describe("getProjectResourceSummaryTone", () => {
+  test("returns success when everything is online", () => {
+    expect(
+      getProjectResourceSummaryTone({
+        serviceCount: 1,
+        databaseCount: 1,
+        totalCount: 2,
+        onlineCount: 2,
+        attentionCount: 0,
+      }),
+    ).toBe("success");
+  });
+
+  test("returns warning when only part of the project is online", () => {
+    expect(
+      getProjectResourceSummaryTone({
+        serviceCount: 1,
+        databaseCount: 1,
+        totalCount: 2,
+        onlineCount: 1,
+        attentionCount: 0,
+      }),
+    ).toBe("warning");
+  });
+
+  test("returns danger when nothing is online", () => {
+    expect(
+      getProjectResourceSummaryTone({
+        serviceCount: 1,
+        databaseCount: 1,
+        totalCount: 2,
+        onlineCount: 0,
+        attentionCount: 0,
+      }),
+    ).toBe("danger");
+  });
+});
+
+describe("formatProjectResourceBreakdown", () => {
+  test("formats services and databases", () => {
+    expect(
+      formatProjectResourceBreakdown({
+        serviceCount: 1,
+        databaseCount: 1,
+        totalCount: 2,
+        onlineCount: 2,
+        attentionCount: 0,
+      }),
+    ).toBe("1 service, 1 database");
+  });
+});

--- a/apps/app/src/lib/project-resource-summary.ts
+++ b/apps/app/src/lib/project-resource-summary.ts
@@ -1,0 +1,97 @@
+import type {
+  ServiceAttentionStatus,
+  ServiceRuntimeStatus,
+} from "./service-runtime-status";
+
+interface ProjectResourceItem {
+  runtimeStatus: ServiceRuntimeStatus;
+  attentionStatus: ServiceAttentionStatus;
+}
+
+export interface ProjectResourceSummary {
+  serviceCount: number;
+  databaseCount: number;
+  totalCount: number;
+  onlineCount: number;
+  attentionCount: number;
+}
+
+export type ProjectResourceSummaryTone =
+  | "neutral"
+  | "success"
+  | "warning"
+  | "danger";
+
+function countOnline(resources: ProjectResourceItem[]): number {
+  return resources.filter(function isOnline(resource) {
+    return resource.runtimeStatus === "online";
+  }).length;
+}
+
+function countAttention(resources: ProjectResourceItem[]): number {
+  return resources.filter(function hasAttention(resource) {
+    return resource.attentionStatus !== null;
+  }).length;
+}
+
+function formatCount(count: number, label: string): string {
+  return `${count} ${label}${count === 1 ? "" : "s"}`;
+}
+
+export function getProjectResourceSummary(input: {
+  services: ProjectResourceItem[];
+  databases: ProjectResourceItem[];
+}): ProjectResourceSummary {
+  const serviceCount = input.services.length;
+  const databaseCount = input.databases.length;
+
+  return {
+    serviceCount,
+    databaseCount,
+    totalCount: serviceCount + databaseCount,
+    onlineCount: countOnline(input.services) + countOnline(input.databases),
+    attentionCount:
+      countAttention(input.services) + countAttention(input.databases),
+  };
+}
+
+export function getProjectResourceSummaryTone(
+  summary: ProjectResourceSummary,
+): ProjectResourceSummaryTone {
+  if (summary.totalCount === 0) {
+    return "neutral";
+  }
+
+  if (
+    summary.onlineCount === summary.totalCount &&
+    summary.attentionCount === 0
+  ) {
+    return "success";
+  }
+
+  if (summary.onlineCount === 0) {
+    return "danger";
+  }
+
+  return "warning";
+}
+
+export function formatProjectResourceBreakdown(
+  summary: ProjectResourceSummary,
+): string {
+  if (summary.totalCount === 0) {
+    return "0 resources";
+  }
+
+  const parts: string[] = [];
+
+  if (summary.serviceCount > 0) {
+    parts.push(formatCount(summary.serviceCount, "service"));
+  }
+
+  if (summary.databaseCount > 0) {
+    parts.push(formatCount(summary.databaseCount, "database"));
+  }
+
+  return parts.join(", ");
+}

--- a/apps/app/src/server/databases.ts
+++ b/apps/app/src/server/databases.ts
@@ -7,7 +7,7 @@ import {
   deployDatabaseTarget,
   getDatabase,
   getDatabaseTargetRuntime,
-  listDatabasesByProject,
+  listDatabasesWithRuntimeByProject,
   listDatabaseTargetDeployments,
   listDatabaseTargets,
   patchDatabase,
@@ -167,7 +167,7 @@ export const databases = {
   }),
 
   list: os.databases.list.handler(async ({ input }) => {
-    return listDatabasesByProject(input.projectId);
+    return listDatabasesWithRuntimeByProject(input.projectId);
   }),
 
   get: os.databases.get.handler(async ({ input }) => {

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -1,10 +1,12 @@
 import { ORPCError } from "@orpc/server";
 import { getSetting } from "@/lib/auth";
+import { listDatabasesWithRuntimeByProject } from "@/lib/database-runtime";
 import { db } from "@/lib/db";
 import { deployProject, deployService } from "@/lib/deployer";
 import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
 import { newEnvironmentId, newProjectId } from "@/lib/id";
 import { cleanupProject } from "@/lib/lifecycle";
+import { getProjectResourceSummary } from "@/lib/project-resource-summary";
 import { createService } from "@/lib/services";
 import { slugify } from "@/lib/slugify";
 import { getTemplate, resolveTemplateServices } from "@/lib/templates";
@@ -24,12 +26,15 @@ export const projects = {
 
     return Promise.all(
       projectRows.map(async (project) => {
-        const productionEnv = await db
-          .selectFrom("environments")
-          .select("id")
-          .where("projectId", "=", project.id)
-          .where("type", "=", "production")
-          .executeTakeFirst();
+        const [productionEnv, databases] = await Promise.all([
+          db
+            .selectFrom("environments")
+            .select("id")
+            .where("projectId", "=", project.id)
+            .where("type", "=", "production")
+            .executeTakeFirst(),
+          listDatabasesWithRuntimeByProject(project.id),
+        ]);
 
         const services = productionEnv
           ? await db
@@ -41,6 +46,10 @@ export const projects = {
 
         const servicesWithDeployments =
           await addLatestDeploymentsWithRuntimeStatus(services);
+        const resourceSummary = getProjectResourceSummary({
+          services: servicesWithDeployments,
+          databases,
+        });
 
         let latestDeployment: {
           status: string;
@@ -93,6 +102,7 @@ export const projects = {
             : null,
           repoUrl,
           runningUrl,
+          resourceSummary,
           services: servicesWithDeployments.map((service) => ({
             id: service.id,
             name: service.name,


### PR DESCRIPTION
## Summary
- include databases in project health summaries so counts reflect all project resources
- add shared resource summary and badge helpers to keep workspace status UI consistent
- expose database runtime status in project database lists and menus

## Testing
- bun --cwd apps/app test src/lib/database-runtime-status.test.ts src/lib/project-resource-summary.test.ts
- bun run typecheck
- bun run lint
