### PR TITLE
fix(github): use dot status icons in pr comments

### DIFF
--- a/apps/app/src/lib/webhook.test.ts
+++ b/apps/app/src/lib/webhook.test.ts
@@ -1,6 +1,31 @@
 import { describe, expect, test } from "bun:test";
 import { createHmac } from "node:crypto";
-import { verifyWebhookSignature } from "./webhook";
+import { buildPRCommentBody, verifyWebhookSignature } from "./webhook";
+
+const STATUS_ICON_BASE_URL = "https://frost.build/static/status";
+const SERVICE_DASHBOARD_URL =
+  "https://demo.frost.build/projects/proj_123/environments/env_123/services/svc_123";
+
+function buildCommentBodyForTest(
+  status: string,
+  previewUrl: string | null = null,
+  frostDomain: string | null = "demo.frost.build",
+): string {
+  return buildPRCommentBody({
+    services: [
+      {
+        id: "svc_123",
+        name: "frost",
+        hostname: "frost",
+        status,
+        url: previewUrl,
+      },
+    ],
+    projectId: "proj_123",
+    environmentId: "env_123",
+    frostDomain,
+  });
+}
 
 describe("verifyWebhookSignature", () => {
   const secret = "test-secret";
@@ -36,5 +61,44 @@ describe("verifyWebhookSignature", () => {
     expect(verifyWebhookSignature(payload, signature, "wrong-secret")).toBe(
       false,
     );
+  });
+});
+
+describe("buildPRCommentBody", () => {
+  test("renders ready status with plain circle and linked text", () => {
+    const body = buildCommentBodyForTest(
+      "running",
+      "https://preview.example.com",
+    );
+
+    expect(body).toContain(
+      `![](${STATUS_ICON_BASE_URL}/ready-dot.svg) [Ready](${SERVICE_DASHBOARD_URL})`,
+    );
+    expect(body).toContain("[Visit](https://preview.example.com)");
+  });
+
+  test("renders failed status with linked text", () => {
+    const body = buildCommentBodyForTest("failed");
+
+    expect(body).toContain(
+      `![](${STATUS_ICON_BASE_URL}/failed-dot.svg) [Failed](${SERVICE_DASHBOARD_URL})`,
+    );
+  });
+
+  test("renders building status with linked text", () => {
+    const body = buildCommentBodyForTest("pending");
+
+    expect(body).toContain(
+      `![](${STATUS_ICON_BASE_URL}/building-dot.svg) [Building](${SERVICE_DASHBOARD_URL})`,
+    );
+  });
+
+  test("renders plain status text when dashboard url is missing", () => {
+    const body = buildCommentBodyForTest("running", null, null);
+
+    expect(body).toContain(
+      `| frost | ![](${STATUS_ICON_BASE_URL}/ready-dot.svg) Ready | - |`,
+    );
+    expect(body).not.toContain("[Ready](");
   });
 });

--- a/apps/app/src/lib/webhook.ts
+++ b/apps/app/src/lib/webhook.ts
@@ -298,16 +298,31 @@ export interface BuildPRCommentParams {
   frostDomain: string | null;
 }
 
-function getStatusLabel(status: string): { label: string; icon: string } {
-  if (status === "running") return { label: "Ready", icon: "ready" };
-  if (status === "failed") return { label: "Failed", icon: "failed" };
-  return { label: "Building", icon: "building" };
+const STATUS_ICON_BASE_URL = "https://frost.build/static/status";
+
+function getStatusLabel(status: string): { label: string; iconFile: string } {
+  if (status === "running") {
+    return {
+      label: "Ready",
+      iconFile: "ready-dot.svg",
+    };
+  }
+  if (status === "failed") {
+    return {
+      label: "Failed",
+      iconFile: "failed-dot.svg",
+    };
+  }
+  return {
+    label: "Building",
+    iconFile: "building-dot.svg",
+  };
 }
 
 function getStatusCell(status: string, dashboardUrl: string | null): string {
-  const { label, icon } = getStatusLabel(status);
+  const { label, iconFile } = getStatusLabel(status);
   const linked = dashboardUrl ? `[${label}](${dashboardUrl})` : label;
-  return `![](https://frost.build/static/status/${icon}.svg) ${linked}`;
+  return `![](${STATUS_ICON_BASE_URL}/${iconFile}) ${linked}`;
 }
 
 export function buildPRCommentBody(params: BuildPRCommentParams): string {

--- a/apps/marketing/public/static/status/building-dot.svg
+++ b/apps/marketing/public/static/status/building-dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="4" fill="#f59e0b"/>
+</svg>

--- a/apps/marketing/public/static/status/failed-dot.svg
+++ b/apps/marketing/public/static/status/failed-dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="4" fill="#ef4444"/>
+</svg>

--- a/apps/marketing/public/static/status/ready-dot.svg
+++ b/apps/marketing/public/static/status/ready-dot.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+  <circle cx="5" cy="5" r="4" fill="#10b981"/>
+</svg>


### PR DESCRIPTION
## Summary
- replace GH PR comment status badges with small SVG dot icons
- keep the dot plain and keep only the status text linked
- add focused tests for ready, failed, building, and no-dashboard cases

## Testing
- bun run typecheck
- bun run lint
- bun --cwd apps/app test src/lib/webhook.test.ts
