### PR TITLE
fix(ui): standardize date display format

### DIFF
--- a/apps/app/src/app/(workspace)/_components/project-card.tsx
+++ b/apps/app/src/app/(workspace)/_components/project-card.tsx
@@ -1,6 +1,7 @@
 import { GitBranch, Github } from "lucide-react";
 import Link from "next/link";
 import type { ProjectLatestDeployment, ProjectListItem } from "@/lib/api";
+import { formatDateTime } from "@/lib/time";
 import { ProjectAvatar } from "./project-avatar";
 import { ProjectResourceBadges } from "./project-resource-badges";
 
@@ -12,7 +13,7 @@ function formatTimeAgo(timestamp: number): string {
   if (seconds < 86400) return `${Math.floor(seconds / 3600)}h ago`;
   if (seconds < 604800) return `${Math.floor(seconds / 86400)}d ago`;
 
-  return new Date(timestamp).toLocaleDateString();
+  return formatDateTime(timestamp);
 }
 
 function extractRepoPath(url: string): string | null {

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-backup-settings-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-backup-settings-panel.tsx
@@ -25,6 +25,7 @@ import {
   useTestDatabaseBackupConnection,
   useUpsertDatabaseBackupConfig,
 } from "@/hooks/use-databases";
+import { formatDateTime } from "@/lib/time";
 
 type BackupIntervalUnit = "minutes" | "hours" | "days";
 type BackupProvider = "aws" | "cloudflare" | "backblaze" | "custom";
@@ -81,7 +82,7 @@ function parseBackblazeRegion(endpoint: string | null): string {
 }
 
 function formatDate(value: number): string {
-  return new Date(value).toLocaleString();
+  return formatDateTime(value);
 }
 
 function formatBackupLabel(input: {

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/runtime-metrics-card.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/runtime-metrics-card.tsx
@@ -12,6 +12,7 @@ import {
 } from "recharts";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { useRuntimeMetrics } from "@/hooks/use-monitoring";
+import { formatDateTime, formatTimeOfDay } from "@/lib/time";
 
 interface RuntimeMetricsCardProps {
   runtimeServiceId: string;
@@ -23,9 +24,12 @@ const RANGES = [
   { value: "6h", label: "6h" },
 ];
 
-function formatTime(label: unknown): string {
-  const date = new Date(Number(label));
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+function formatAxisTime(label: unknown): string {
+  return formatTimeOfDay(Number(label));
+}
+
+function formatTooltipTime(label: unknown): string {
+  return formatDateTime(Number(label));
 }
 
 function formatBytes(bytes: number): string {
@@ -134,7 +138,7 @@ export function RuntimeMetricsCard({
                     </defs>
                     <XAxis
                       dataKey="timestamp"
-                      tickFormatter={formatTime}
+                      tickFormatter={formatAxisTime}
                       tick={{ fill: "#737373", fontSize: 9 }}
                       axisLine={{ stroke: "#404040" }}
                       tickLine={false}
@@ -156,7 +160,7 @@ export function RuntimeMetricsCard({
                         fontSize: "11px",
                       }}
                       labelStyle={{ color: "#a3a3a3" }}
-                      labelFormatter={(label) => formatTime(label as number)}
+                      labelFormatter={formatTooltipTime}
                       formatter={(value) => [
                         `${Number(value).toFixed(1)}%`,
                         "CPU",
@@ -212,7 +216,7 @@ export function RuntimeMetricsCard({
                     </defs>
                     <XAxis
                       dataKey="timestamp"
-                      tickFormatter={formatTime}
+                      tickFormatter={formatAxisTime}
                       tick={{ fill: "#737373", fontSize: 9 }}
                       axisLine={{ stroke: "#404040" }}
                       tickLine={false}
@@ -234,7 +238,7 @@ export function RuntimeMetricsCard({
                         fontSize: "11px",
                       }}
                       labelStyle={{ color: "#a3a3a3" }}
-                      labelFormatter={(label) => formatTime(label as number)}
+                      labelFormatter={formatTooltipTime}
                       formatter={(value, _name, props) => {
                         const percent = `${Number(value).toFixed(1)}%`;
                         const bytes = props.payload?.bytes;

--- a/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/environments/[envId]/databases/[databaseId]/branches/page.tsx
@@ -38,6 +38,7 @@ import {
   useResetDatabaseTarget,
 } from "@/hooks/use-databases";
 import { orpc } from "@/lib/orpc-client";
+import { formatDateTime } from "@/lib/time";
 
 type HierarchyTarget = {
   id: string;
@@ -47,7 +48,7 @@ type HierarchyTarget = {
 
 function formatDate(value: number | null): string {
   if (!value) return "-";
-  return new Date(value).toLocaleString();
+  return formatDateTime(value);
 }
 
 function compareTargetNames(a: HierarchyTarget, b: HierarchyTarget): number {

--- a/apps/app/src/app/(workspace)/projects/[id]/services/new/_components/repo-selector.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/services/new/_components/repo-selector.tsx
@@ -7,6 +7,7 @@ import { useMemo, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { orpc } from "@/lib/orpc-client";
+import { formatDateTime } from "@/lib/time";
 
 interface RepoSelectorProps {
   onSelect: (repo: {
@@ -29,7 +30,7 @@ function formatTimeAgo(dateString: string): string {
   if (diffMins < 60) return `${diffMins}m ago`;
   if (diffHours < 24) return `${diffHours}h ago`;
   if (diffDays < 30) return `${diffDays}d ago`;
-  return date.toLocaleDateString();
+  return formatDateTime(date);
 }
 
 export function RepoSelector({ onSelect }: RepoSelectorProps) {

--- a/apps/app/src/app/(workspace)/settings/_components/system-section.tsx
+++ b/apps/app/src/app/(workspace)/settings/_components/system-section.tsx
@@ -18,6 +18,7 @@ import { StatusNotice } from "@/components/status-notice";
 import { Button } from "@/components/ui/button";
 import { useDemoMode } from "@/hooks/use-demo-mode";
 import { orpc } from "@/lib/orpc-client";
+import { formatDateTime } from "@/lib/time";
 
 type UpdateState = "idle" | "preparing" | "restarting" | "success" | "failed";
 
@@ -142,7 +143,7 @@ export function SystemSection() {
     if (minutes < 60) return `${minutes} minute${minutes === 1 ? "" : "s"} ago`;
     const hours = Math.floor(minutes / 60);
     if (hours < 24) return `${hours} hour${hours === 1 ? "" : "s"} ago`;
-    return new Date(timestamp).toLocaleDateString();
+    return formatDateTime(timestamp);
   }
 
   const isUpdating =

--- a/apps/app/src/app/(workspace)/settings/api-keys/_components/api-keys-section.tsx
+++ b/apps/app/src/app/(workspace)/settings/api-keys/_components/api-keys-section.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { useDemoMode } from "@/hooks/use-demo-mode";
 import { orpc } from "@/lib/orpc-client";
+import { formatDateTime } from "@/lib/time";
 
 export function ApiKeysSection() {
   const demoMode = useDemoMode();
@@ -71,11 +72,7 @@ export function ApiKeysSection() {
 
   function formatDate(dateStr: string | null) {
     if (!dateStr) return "Never";
-    return new Date(dateStr).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
+    return formatDateTime(dateStr);
   }
 
   return (

--- a/apps/app/src/app/(workspace)/settings/cleanup/_components/run-cleanup-card.tsx
+++ b/apps/app/src/app/(workspace)/settings/cleanup/_components/run-cleanup-card.tsx
@@ -4,6 +4,7 @@ import { CheckCircle2, Loader2, Play, XCircle } from "lucide-react";
 import { SettingCard } from "@/components/setting-card";
 import { StatusNotice } from "@/components/status-notice";
 import { Button } from "@/components/ui/button";
+import { formatDateTime } from "@/lib/time";
 import type { CleanupSettings } from "./use-cleanup-settings";
 
 interface RunCleanupCardProps {
@@ -23,7 +24,7 @@ function formatBytes(bytes: number): string {
 
 function formatDate(dateStr: string | null): string {
   if (!dateStr) return "Never";
-  return new Date(dateStr).toLocaleString();
+  return formatDateTime(dateStr);
 }
 
 export function RunCleanupCard({

--- a/apps/app/src/app/(workspace)/settings/mcp-tokens/_components/mcp-tokens-section.tsx
+++ b/apps/app/src/app/(workspace)/settings/mcp-tokens/_components/mcp-tokens-section.tsx
@@ -9,6 +9,7 @@ import { SettingCard } from "@/components/setting-card";
 import { Button } from "@/components/ui/button";
 import { useDemoMode } from "@/hooks/use-demo-mode";
 import { orpc } from "@/lib/orpc-client";
+import { formatDateTime } from "@/lib/time";
 
 export function McpTokensSection() {
   const demoMode = useDemoMode();
@@ -31,11 +32,7 @@ export function McpTokensSection() {
   );
 
   function formatDate(dateStr: string) {
-    return new Date(dateStr).toLocaleDateString(undefined, {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-    });
+    return formatDateTime(dateStr);
   }
 
   return (

--- a/apps/app/src/app/(workspace)/settings/monitoring/_components/metric-chart.tsx
+++ b/apps/app/src/app/(workspace)/settings/monitoring/_components/metric-chart.tsx
@@ -8,6 +8,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
+import { formatDateTime, formatTimeOfDay } from "@/lib/time";
 
 interface DataPoint {
   timestamp: number;
@@ -22,9 +23,12 @@ interface MetricChartProps {
   height?: number;
 }
 
-function formatTime(label: unknown): string {
-  const date = new Date(Number(label));
-  return date.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+function formatAxisTime(label: unknown): string {
+  return formatTimeOfDay(Number(label));
+}
+
+function formatTooltipTime(label: unknown): string {
+  return formatDateTime(Number(label));
 }
 
 export function MetricChart({
@@ -66,7 +70,7 @@ export function MetricChart({
           </defs>
           <XAxis
             dataKey="timestamp"
-            tickFormatter={formatTime}
+            tickFormatter={formatAxisTime}
             tick={{ fill: "#737373", fontSize: 10 }}
             axisLine={{ stroke: "#404040" }}
             tickLine={false}
@@ -88,7 +92,7 @@ export function MetricChart({
               fontSize: "12px",
             }}
             labelStyle={{ color: "#a3a3a3" }}
-            labelFormatter={(label) => formatTime(label as number)}
+            labelFormatter={formatTooltipTime}
             formatter={(value) => [`${Number(value).toFixed(1)}${unit}`, label]}
           />
           <Area

--- a/apps/app/src/components/log-viewer.tsx
+++ b/apps/app/src/components/log-viewer.tsx
@@ -2,6 +2,7 @@
 
 import { ArrowDown, Circle } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { formatDateTime } from "@/lib/time";
 import { cn } from "@/lib/utils";
 
 function parseLogLine(line: string): {
@@ -18,17 +19,7 @@ function parseLogLine(line: string): {
 }
 
 function formatTimestamp(iso: string): string {
-  try {
-    const date = new Date(iso);
-    return date.toLocaleTimeString("en-US", {
-      hour12: false,
-      hour: "2-digit",
-      minute: "2-digit",
-      second: "2-digit",
-    });
-  } catch {
-    return iso;
-  }
+  return formatDateTime(iso, iso);
 }
 
 interface LogViewerProps {

--- a/apps/app/src/lib/time.ts
+++ b/apps/app/src/lib/time.ts
@@ -1,3 +1,45 @@
+function padTimePart(value: number): string {
+  return String(value).padStart(2, "0");
+}
+
+function toValidDate(value: number | string | Date): Date | null {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+function formatDatePart(date: Date): string {
+  return `${date.getFullYear()}-${padTimePart(date.getMonth() + 1)}-${padTimePart(date.getDate())}`;
+}
+
+function formatTimePart(date: Date): string {
+  return `${padTimePart(date.getHours())}:${padTimePart(date.getMinutes())}:${padTimePart(date.getSeconds())}`;
+}
+
+function formatTimeOfDayPart(date: Date): string {
+  return `${padTimePart(date.getHours())}:${padTimePart(date.getMinutes())}`;
+}
+
+export function formatDateTime(
+  value: number | string | Date,
+  fallback = "-",
+): string {
+  const date = toValidDate(value);
+  if (!date) return fallback;
+
+  return `${formatDatePart(date)} ${formatTimePart(date)}`;
+}
+
+export function formatTimeOfDay(
+  value: number | string | Date,
+  fallback = "-",
+): string {
+  const date = toValidDate(value);
+  if (!date) return fallback;
+
+  return formatTimeOfDayPart(date);
+}
+
 export function getTimeAgo(date: Date): string {
   const seconds = Math.floor((Date.now() - date.getTime()) / 1000);
   if (seconds < 60) return "just now";


### PR DESCRIPTION
## Summary
- standardize absolute date displays to `yyyy-MM-dd HH:mm:ss`
- reuse shared time helpers across workspace views, settings, and logs
- keep chart axes compact with `HH:mm` while using full timestamps in tooltips

## Testing
- bun run typecheck
- bun run lint
