### PR TITLE
fix(db): use public host for direct postgres urls

### DIFF
--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-branch-panel.tsx
@@ -20,6 +20,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import type { ContractOutputs } from "@/contracts";
+import { useDatabasePublicHost } from "@/hooks/use-database-public-host";
 import { useDatabaseTargetLogs } from "@/hooks/use-database-target-logs";
 import {
   useDatabaseTargetRuntime,
@@ -46,6 +47,7 @@ export interface DatabaseProviderRef {
 interface Branch {
   id: string;
   name: string;
+  hostname: string;
   lifecycleStatus: "active" | "stopped" | "expired";
   createdAt: number;
 }
@@ -189,6 +191,7 @@ export function DatabaseBranchPanel({
     null,
   );
   const [sqlError, setSqlError] = useState<string | null>(null);
+  const publicHost = useDatabasePublicHost();
 
   const { logs, isConnected, error } = useDatabaseTargetLogs({
     databaseId,
@@ -255,14 +258,15 @@ export function DatabaseBranchPanel({
       if (!branch || !providerRef) {
         return null;
       }
+
       return getConnectionString({
         engine,
-        host: "127.0.0.1",
+        host: publicHost,
         port: providerRef.hostPort,
         providerRef,
       });
     },
-    [branch, engine, providerRef],
+    [branch, engine, providerRef, publicHost],
   );
 
   const internalConnectionString = useMemo(
@@ -275,9 +279,9 @@ export function DatabaseBranchPanel({
         engine === "postgres"
           ? getDatabaseBranchInternalHost(
               databaseName,
-              runtime?.hostname ?? branch.name,
+              runtime?.hostname ?? branch.hostname,
             )
-          : `${runtime?.hostname ?? branch.name}.frost.internal`;
+          : `${runtime?.hostname ?? branch.hostname}.frost.internal`;
 
       return getConnectionString({
         engine,

--- a/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
+++ b/apps/app/src/app/(workspace)/projects/[id]/_components/database-import-wizard.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import type { ContractOutputs } from "@/contracts";
+import { useDatabasePublicHost } from "@/hooks/use-database-public-host";
 import {
   useCreateDatabaseImportJob,
   useDatabaseImportJob,
@@ -172,22 +173,13 @@ export function DatabaseImportWizard({
   const [jobId, setJobId] = useState("");
   const [sourceUrl, setSourceUrl] = useState("");
   const [currentJob, setCurrentJob] = useState<DatabaseImportJob | null>(null);
-  const [externalHost, setExternalHost] = useState("127.0.0.1");
   const [stickLogToBottom, setStickLogToBottom] = useState(true);
   const logRef = useRef<HTMLTextAreaElement | null>(null);
+  const publicHost = useDatabasePublicHost();
 
   const createJobMutation = useCreateDatabaseImportJob(projectId);
   const jobQuery = useDatabaseImportJob(jobId);
   const runImportMutation = useRunDatabaseImportJob(jobId);
-
-  useEffect(function resolveExternalHost() {
-    if (typeof window === "undefined") {
-      return;
-    }
-    if (window.location.hostname) {
-      setExternalHost(window.location.hostname);
-    }
-  }, []);
 
   const job = jobQuery.data ?? currentJob;
 
@@ -269,7 +261,7 @@ export function DatabaseImportWizard({
     ? getConnectionString({
         username: job.targetConnection.username,
         password: job.targetConnection.password,
-        host: externalHost,
+        host: publicHost,
         port: job.targetConnection.hostPort,
         database: job.targetConnection.database,
         ssl: job.targetConnection.ssl,

--- a/apps/app/src/hooks/use-database-public-host.ts
+++ b/apps/app/src/hooks/use-database-public-host.ts
@@ -1,0 +1,23 @@
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { getDatabasePublicHost } from "@/lib/database-public-host";
+import { orpc } from "@/lib/orpc-client";
+
+export function useDatabasePublicHost(): string {
+  const [appHost, setAppHost] = useState<string | null>(null);
+  const { data: settings } = useQuery(orpc.settings.get.queryOptions());
+
+  useEffect(function syncAppHost() {
+    if (typeof window === "undefined") {
+      return;
+    }
+    setAppHost(window.location.hostname || null);
+  }, []);
+
+  return getDatabasePublicHost({
+    appHost,
+    serverIp: settings?.serverIp ?? null,
+  });
+}

--- a/apps/app/src/lib/database-public-host.test.ts
+++ b/apps/app/src/lib/database-public-host.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { getDatabasePublicHost } from "./database-public-host";
+
+describe("getDatabasePublicHost", () => {
+  test("returns app host in local development", () => {
+    expect(
+      getDatabasePublicHost({
+        appHost: "localhost",
+        serverIp: "localhost",
+      }),
+    ).toBe("localhost");
+  });
+
+  test("falls back to server ip when no wildcard exists", () => {
+    expect(
+      getDatabasePublicHost({
+        appHost: "frost.example.com",
+        serverIp: "203.0.113.10",
+      }),
+    ).toBe("203.0.113.10");
+  });
+
+  test("falls back to app host when server ip is missing", () => {
+    expect(
+      getDatabasePublicHost({
+        appHost: "frost.example.com",
+        serverIp: null,
+      }),
+    ).toBe("frost.example.com");
+  });
+});

--- a/apps/app/src/lib/database-public-host.ts
+++ b/apps/app/src/lib/database-public-host.ts
@@ -1,0 +1,38 @@
+function normalizeValue(value: string | null | undefined): string | null {
+  const nextValue = value?.trim();
+  if (!nextValue) {
+    return null;
+  }
+  return nextValue;
+}
+
+function isLoopbackHost(value: string): boolean {
+  return (
+    value === "localhost" ||
+    value === "127.0.0.1" ||
+    value === "::1" ||
+    value === "0.0.0.0"
+  );
+}
+
+export function getDatabasePublicHost(input: {
+  appHost: string | null;
+  serverIp: string | null;
+}): string {
+  const appHost = normalizeValue(input.appHost);
+  const serverIp = normalizeValue(input.serverIp);
+
+  if (appHost && (!serverIp || isLoopbackHost(serverIp))) {
+    return appHost;
+  }
+
+  if (serverIp) {
+    return serverIp;
+  }
+
+  if (appHost) {
+    return appHost;
+  }
+
+  return "localhost";
+}


### PR DESCRIPTION
## Summary
- switch direct postgres urls from 127.0.0.1 to a public host helper
- use localhost in local dev and external server ip in prod
- share the host logic between branch view and import wizard

## Testing
- bun test apps/app/src/lib/database-public-host.test.ts apps/app/src/lib/cloudflare.test.ts
- bun run typecheck
- bun run lint
