### PR TITLE
fix(templates): use managed postgres in project templates

### DIFF
--- a/apps/app/scripts/e2e/group-19-templates.sh
+++ b/apps/app/scripts/e2e/group-19-templates.sh
@@ -194,16 +194,39 @@ log "Services on shared network: $NETWORK_NAME"
 log "Cleanup..."
 api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
 
-log "=== Project Template Restrictions ==="
+log "=== Project Templates ==="
 
-log "Verifying wordpress project template is rejected..."
-WORDPRESS_TEMPLATE_RESP=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-proj-template","templateId":"wordpress"}')
-WORDPRESS_TEMPLATE_ID=$(echo "$WORDPRESS_TEMPLATE_RESP" | jq -r '.id // empty')
-[ -z "$WORDPRESS_TEMPLATE_ID" ] || fail "Wordpress template should not create a project: $WORDPRESS_TEMPLATE_RESP"
-echo "$WORDPRESS_TEMPLATE_RESP" | grep -qi "not supported\|database services" || fail "Expected unsupported template error: $WORDPRESS_TEMPLATE_RESP"
-log "Wordpress template correctly rejected"
+log "Creating hasura project template..."
+PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-proj-template","templateId":"hasura"}')
+PROJECT_ID=$(require_field "$PROJECT" '.id' "create template project") || fail "Failed: $PROJECT"
+ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"
+
+log "Checking template project services..."
+PROJECT_DATA=$(api "$BASE_URL/api/projects/$PROJECT_ID")
+HASURA_SERVICE_ID=$(echo "$PROJECT_DATA" | jq -r '.services[] | select(.name == "hasura") | .id')
+POSTGRES_SERVICE_ID=$(echo "$PROJECT_DATA" | jq -r '.services[] | select(.name == "postgres") | .id')
+[ -n "$HASURA_SERVICE_ID" ] || fail "hasura service missing: $PROJECT_DATA"
+[ -z "$POSTGRES_SERVICE_ID" ] || fail "postgres should be a managed database, not a service: $PROJECT_DATA"
+
+log "Checking managed databases..."
+DATABASES=$(api "$BASE_URL/api/projects/$PROJECT_ID/databases")
+POSTGRES_DB_ID=$(echo "$DATABASES" | jq -r '.[] | select(.name == "postgres") | .id')
+[ -n "$POSTGRES_DB_ID" ] || fail "managed postgres database missing: $DATABASES"
+DB_COUNT=$(echo "$DATABASES" | jq -r 'length')
+[ "$DB_COUNT" = "1" ] || fail "expected 1 managed database, got: $DATABASES"
+
+log "Waiting for hasura deployment..."
+HASURA_DEPLOY_ID=$(wait_for_service_deployment_id "$HASURA_SERVICE_ID" 45 1) || fail "No deployment found for hasura service"
+wait_for_deployment "$HASURA_DEPLOY_ID" 120 || fail "hasura deployment failed"
+
+HASURA_DEPLOY=$(api "$BASE_URL/api/deployments/$HASURA_DEPLOY_ID")
+HASURA_HOST_PORT=$(require_field "$HASURA_DEPLOY" '.hostPort' "get hasura hostPort") || fail "No hostPort"
+HASURA_HEALTH=$(remote "curl -sf --max-time 10 http://localhost:$HASURA_HOST_PORT/healthz" 2>&1 || echo "failed")
+echo "$HASURA_HEALTH" | grep -qi "ok" || fail "hasura health failed: $HASURA_HEALTH"
+log "Project template uses managed postgres and boots"
 
 log "Verifying database template is rejected from service template create..."
+api -X DELETE "$BASE_URL/api/projects/$PROJECT_ID" > /dev/null
 PROJECT=$(api -X POST "$BASE_URL/api/projects" -d '{"name":"e2e-db-template-reject"}')
 PROJECT_ID=$(require_field "$PROJECT" '.id' "create project") || fail "Failed: $PROJECT"
 ENV_ID=$(get_default_environment "$PROJECT_ID") || fail "Failed to get environment"

--- a/apps/app/src/app/(workspace)/projects/new/page.tsx
+++ b/apps/app/src/app/(workspace)/projects/new/page.tsx
@@ -26,7 +26,7 @@ interface TemplateInfoProps {
   template:
     | {
         description: string;
-        services: Record<string, unknown>;
+        services: Record<string, { type?: "database" | "app" }>;
         docs?: string;
       }
     | undefined;
@@ -35,18 +35,30 @@ interface TemplateInfoProps {
 function TemplateInfo({ template }: TemplateInfoProps) {
   if (!template) return null;
 
-  const serviceNames = Object.keys(template.services);
-  const serviceCount = serviceNames.length;
+  const serviceNames = Object.entries(template.services)
+    .filter(([, service]) => service.type !== "database")
+    .map(([name]) => name);
+  const databaseNames = Object.entries(template.services)
+    .filter(([, service]) => service.type === "database")
+    .map(([name]) => name);
 
   return (
     <div className="rounded-lg border border-neutral-700 bg-neutral-800/50 p-3 text-xs text-neutral-400">
       <p className="mb-2 font-medium text-neutral-300">
         {template.description}
       </p>
-      <p>
-        Creates {serviceCount} service{serviceCount > 1 ? "s" : ""}:{" "}
-        {serviceNames.join(", ")}
-      </p>
+      {serviceNames.length > 0 && (
+        <p>
+          Creates {serviceNames.length} service
+          {serviceNames.length > 1 ? "s" : ""}: {serviceNames.join(", ")}
+        </p>
+      )}
+      {databaseNames.length > 0 && (
+        <p className={serviceNames.length > 0 ? "mt-1" : undefined}>
+          Creates {databaseNames.length} database
+          {databaseNames.length > 1 ? "s" : ""}: {databaseNames.join(", ")}
+        </p>
+      )}
       {template.docs && (
         <p className="mt-2">
           <a

--- a/apps/app/src/lib/templates.test.ts
+++ b/apps/app/src/lib/templates.test.ts
@@ -4,6 +4,7 @@ import {
   clearTemplateCache,
   generateCredential,
   getDatabaseTemplates,
+  getManagedTemplateDatabases,
   getProjectTemplates,
   getServiceTemplates,
   getTemplate,
@@ -102,6 +103,34 @@ describe("generateCredential", () => {
   });
 });
 
+describe("getManagedTemplateDatabases", () => {
+  it("returns supported managed databases only", () => {
+    const template = getTemplate("plausible");
+    expect(template).toBeDefined();
+    if (!template) return;
+
+    const databases = getManagedTemplateDatabases(template);
+
+    expect(databases).toEqual([
+      {
+        name: "postgres",
+        engine: "postgres",
+        image: "postgres:16-alpine",
+      },
+    ]);
+  });
+
+  it("leaves mysql database services unmanaged", () => {
+    const template = getTemplate("wordpress");
+    expect(template).toBeDefined();
+    if (!template) return;
+
+    const databases = getManagedTemplateDatabases(template);
+
+    expect(databases).toEqual([]);
+  });
+});
+
 describe("resolveTemplateServices", () => {
   it("resolves a single-service template", () => {
     const template = getTemplate("postgres");
@@ -131,7 +160,9 @@ describe("resolveTemplateServices", () => {
   it("resolves cross-service references in project templates", () => {
     const template = getTemplate("plausible");
     expect(template).toBeDefined();
-    const resolved = resolveTemplateServices(template!);
+    if (!template) return;
+
+    const resolved = resolveTemplateServices(template);
     expect(resolved.length).toBe(3);
 
     const plausibleSvc = resolved.find((s) => s.name === "plausible");
@@ -143,6 +174,54 @@ describe("resolveTemplateServices", () => {
     expect(dbUrlEnv).toBeDefined();
     expect(dbUrlEnv?.value).not.toContain("${");
     expect(dbUrlEnv?.value).toContain("postgres://postgres:");
+  });
+
+  it("can swap managed database refs into project templates", () => {
+    const template = getTemplate("plausible");
+    expect(template).toBeDefined();
+    if (!template) return;
+
+    const resolved = resolveTemplateServices(template, {
+      excludeServices: ["postgres"],
+      referenceValues: {
+        postgres: {
+          HOST: "postgres--main.frost.internal",
+          PORT: "5432",
+          USERNAME: "frost",
+          PASSWORD: "secret",
+          DATABASE: "postgres",
+          DATABASE_URL:
+            "postgres://frost:secret@postgres--main.frost.internal:5432/postgres?sslmode=require",
+          POSTGRES_USER: "frost",
+          POSTGRES_PASSWORD: "secret",
+          POSTGRES_DB: "postgres",
+        },
+      },
+    });
+
+    expect(resolved.map((service) => service.name)).toEqual([
+      "plausible",
+      "clickhouse",
+    ]);
+
+    const plausibleSvc = resolved.find(
+      (service) => service.name === "plausible",
+    );
+    expect(plausibleSvc).toBeDefined();
+
+    const dbUrlEnv = plausibleSvc?.envVars.find(
+      (envVar) => envVar.key === "DATABASE_URL",
+    );
+    const clickhouseUrlEnv = plausibleSvc?.envVars.find(
+      (envVar) => envVar.key === "CLICKHOUSE_DATABASE_URL",
+    );
+
+    expect(dbUrlEnv?.value).toBe(
+      "postgres://frost:secret@postgres--main.frost.internal:5432/postgres?sslmode=require",
+    );
+    expect(clickhouseUrlEnv?.value).toBe(
+      "http://clickhouse:8123/plausible_events_db",
+    );
   });
 
   it("sets main service correctly in project templates", () => {

--- a/apps/app/src/lib/templates.ts
+++ b/apps/app/src/lib/templates.ts
@@ -3,6 +3,7 @@ import { basename, join } from "node:path";
 import { nanoid } from "nanoid";
 import { parse as parseYaml } from "yaml";
 import { z } from "zod";
+import { buildPostgresConnectionString } from "./connection-strings";
 
 const generatedValueSchema = z.object({
   generated: z.enum(["password", "base64_32", "base64_64"]),
@@ -53,6 +54,10 @@ export interface Template {
   services: Record<string, ServiceDefinition>;
 }
 
+export interface TemplateReferenceValues {
+  [serviceName: string]: Record<string, string>;
+}
+
 export interface VolumeMount {
   name: string;
   path: string;
@@ -79,12 +84,69 @@ export interface ResolvedService {
   ssl: boolean;
 }
 
+export interface ResolveTemplateServicesOptions {
+  excludeServices?: string[];
+  referenceValues?: TemplateReferenceValues;
+}
+
+type TemplateDatabaseEngine = "postgres" | "mysql";
+
+export type ManagedTemplateDatabaseEngine = "postgres";
+
+export interface ManagedTemplateDatabase {
+  name: string;
+  engine: ManagedTemplateDatabaseEngine;
+  image: string;
+}
+
 function parseVolumeString(vol: string): VolumeMount {
   const parts = vol.split(":");
   if (parts.length !== 2) {
     throw new Error(`Invalid volume format: ${vol}`);
   }
   return { name: parts[0], path: parts[1] };
+}
+
+function detectTemplateDatabaseEngine(
+  image: string,
+): TemplateDatabaseEngine | null {
+  const normalized = image.toLowerCase();
+
+  if (normalized.includes("postgres")) {
+    return "postgres";
+  }
+
+  if (normalized.includes("mysql")) {
+    return "mysql";
+  }
+
+  return null;
+}
+
+function detectManagedTemplateDatabaseEngine(
+  image: string,
+): ManagedTemplateDatabaseEngine | null {
+  const engine = detectTemplateDatabaseEngine(image);
+
+  if (engine === "postgres") {
+    return engine;
+  }
+
+  return null;
+}
+
+function buildMysqlConnectionString(input: {
+  username: string;
+  password: string;
+  host: string;
+  port: number;
+  database: string;
+}): string {
+  const user = encodeURIComponent(input.username);
+  const password = encodeURIComponent(input.password);
+  const database = encodeURIComponent(input.database);
+
+  return `mysql://${user}:${password}@${input.host}:${input.port}/${database}`;
 }
 
 function loadTemplatesFromDir(dirPath: string, type: TemplateType): Template[] {
@@ -110,7 +172,12 @@ function loadTemplatesFromDir(dirPath: string, type: TemplateType): Template[] {
 }
 
 function getTemplatesDir(): string {
-  return join(process.cwd(), "templates");
+  const directDir = join(process.cwd(), "templates");
+  if (existsSync(directDir)) {
+    return directDir;
+  }
+
+  return join(process.cwd(), "apps", "app", "templates");
 }
 
 let cachedTemplates: Template[] | null = null;
@@ -176,25 +243,177 @@ export function isGeneratedValue(value: EnvValue): value is GeneratedValue {
   return typeof value === "object" && "generated" in value;
 }
 
-export function resolveTemplateServices(template: Template): ResolvedService[] {
-  const generatedValues: Record<string, Record<string, string>> = {};
+function buildTemplateEnvValues(template: Template): TemplateReferenceValues {
+  const envValuesByService: TemplateReferenceValues = {};
 
   for (const [serviceName, service] of Object.entries(template.services)) {
-    generatedValues[serviceName] = {};
+    envValuesByService[serviceName] = {};
+
     if (service.environment) {
       for (const [key, value] of Object.entries(service.environment)) {
         if (isGeneratedValue(value)) {
-          generatedValues[serviceName][key] = generateCredential(
+          envValuesByService[serviceName][key] = generateCredential(
             value.generated,
           );
+        } else {
+          envValuesByService[serviceName][key] = value;
         }
       }
     }
   }
 
+  return envValuesByService;
+}
+
+function buildServiceReferenceValues(
+  serviceName: string,
+  service: ServiceDefinition,
+  envValues: Record<string, string>,
+): Record<string, string> {
+  const refs = { ...envValues };
+
+  refs.HOST ??= serviceName;
+  refs.PORT ??= String(service.port);
+
+  const engine = detectTemplateDatabaseEngine(service.image);
+
+  if (engine === "postgres") {
+    const username = refs.POSTGRES_USER ?? "postgres";
+    const password = refs.POSTGRES_PASSWORD ?? "";
+    const database = refs.POSTGRES_DB ?? "postgres";
+
+    refs.USERNAME ??= username;
+    refs.PASSWORD ??= password;
+    refs.DATABASE ??= database;
+
+    if (password && refs.DATABASE_URL === undefined) {
+      refs.DATABASE_URL = buildPostgresConnectionString({
+        username,
+        password,
+        host: refs.HOST,
+        port: service.port,
+        database,
+        ssl: service.ssl ?? false,
+      });
+    }
+  }
+
+  if (engine === "mysql") {
+    const username = refs.MYSQL_USER ?? "root";
+    const password = refs.MYSQL_PASSWORD ?? refs.MYSQL_ROOT_PASSWORD ?? "";
+    const database = refs.MYSQL_DATABASE ?? "mysql";
+
+    refs.USERNAME ??= username;
+    refs.PASSWORD ??= password;
+    refs.DATABASE ??= database;
+
+    if (password && refs.DATABASE_URL === undefined) {
+      refs.DATABASE_URL = buildMysqlConnectionString({
+        username,
+        password,
+        host: refs.HOST,
+        port: service.port,
+        database,
+      });
+    }
+  }
+
+  return refs;
+}
+
+function buildTemplateReferenceValues(input: {
+  template: Template;
+  envValuesByService: TemplateReferenceValues;
+  overrideValues?: TemplateReferenceValues;
+}): TemplateReferenceValues {
+  const referenceValues: TemplateReferenceValues = {};
+
+  for (const [serviceName, service] of Object.entries(
+    input.template.services,
+  )) {
+    referenceValues[serviceName] = buildServiceReferenceValues(
+      serviceName,
+      service,
+      input.envValuesByService[serviceName] ?? {},
+    );
+  }
+
+  if (input.overrideValues) {
+    for (const [serviceName, values] of Object.entries(input.overrideValues)) {
+      referenceValues[serviceName] = {
+        ...(referenceValues[serviceName] ?? {}),
+        ...values,
+      };
+    }
+  }
+
+  return referenceValues;
+}
+
+function resolveTemplateValue(
+  value: string,
+  referenceValues: TemplateReferenceValues,
+): string {
+  let resolvedValue = value;
+  const refPattern = /\$\{([^.]+)\.([^}]+)\}/g;
+  const matches = value.matchAll(refPattern);
+
+  for (const match of matches) {
+    const [fullMatch, refService, refKey] = match;
+    const refValue = referenceValues[refService]?.[refKey];
+
+    if (refValue !== undefined) {
+      resolvedValue = resolvedValue.replace(fullMatch, refValue);
+    }
+  }
+
+  return resolvedValue;
+}
+
+export function getManagedTemplateDatabases(
+  template: Template,
+): ManagedTemplateDatabase[] {
+  const databases: ManagedTemplateDatabase[] = [];
+
+  for (const [serviceName, service] of Object.entries(template.services)) {
+    if (service.type !== "database") {
+      continue;
+    }
+
+    const engine = detectManagedTemplateDatabaseEngine(service.image);
+    if (!engine) {
+      continue;
+    }
+
+    databases.push({
+      name: serviceName,
+      engine,
+      image: service.image,
+    });
+  }
+
+  return databases;
+}
+
+export function resolveTemplateServices(
+  template: Template,
+  options: ResolveTemplateServicesOptions = {},
+): ResolvedService[] {
+  const envValuesByService = buildTemplateEnvValues(template);
+  const referenceValues = buildTemplateReferenceValues({
+    template,
+    envValuesByService,
+    overrideValues: options.referenceValues,
+  });
+  const excludedServices = new Set(options.excludeServices ?? []);
+
   const resolved: ResolvedService[] = [];
 
   for (const [serviceName, service] of Object.entries(template.services)) {
+    if (excludedServices.has(serviceName)) {
+      continue;
+    }
+
     const envVars: ResolvedEnvVar[] = [];
 
     if (service.environment) {
@@ -202,21 +421,17 @@ export function resolveTemplateServices(template: Template): ResolvedService[] {
         if (isGeneratedValue(value)) {
           envVars.push({
             key,
-            value: generatedValues[serviceName][key],
+            value: envValuesByService[serviceName][key],
             generated: true,
           });
         } else {
-          let resolvedValue = value;
-          const refPattern = /\$\{([^.]+)\.([^}]+)\}/g;
-          const matches = value.matchAll(refPattern);
-          for (const match of matches) {
-            const [fullMatch, refService, refKey] = match;
-            const refValue = generatedValues[refService]?.[refKey];
-            if (refValue) {
-              resolvedValue = resolvedValue.replace(fullMatch, refValue);
-            }
-          }
-          envVars.push({ key, value: resolvedValue });
+          envVars.push({
+            key,
+            value: resolveTemplateValue(
+              envValuesByService[serviceName][key],
+              referenceValues,
+            ),
+          });
         }
       }
     }
@@ -239,7 +454,9 @@ export function resolveTemplateServices(template: Template): ResolvedService[] {
     });
   }
 
-  const mainService = resolved.find((s) => s.isMain);
+  const mainService = resolved.find(function isMainService(service) {
+    return service.isMain;
+  });
   if (!mainService && resolved.length > 0) {
     resolved[0].isMain = true;
   }

--- a/apps/app/src/server/projects.ts
+++ b/apps/app/src/server/projects.ts
@@ -1,6 +1,11 @@
 import { ORPCError } from "@orpc/server";
 import { getSetting } from "@/lib/auth";
-import { listDatabasesWithRuntimeByProject } from "@/lib/database-runtime";
+import { buildPostgresConnectionString } from "@/lib/connection-strings";
+import {
+  createDatabase,
+  getDatabaseTargetConnectionInfo,
+  listDatabasesWithRuntimeByProject,
+} from "@/lib/database-runtime";
 import { db } from "@/lib/db";
 import { deployProject, deployService } from "@/lib/deployer";
 import { addLatestDeploymentsWithRuntimeStatus } from "@/lib/deployment-runtime";
@@ -9,13 +14,45 @@ import { cleanupProject } from "@/lib/lifecycle";
 import { getProjectResourceSummary } from "@/lib/project-resource-summary";
 import { createService } from "@/lib/services";
 import { slugify } from "@/lib/slugify";
-import { getTemplate, resolveTemplateServices } from "@/lib/templates";
+import {
+  getManagedTemplateDatabases,
+  getTemplate,
+  resolveTemplateServices,
+  type TemplateReferenceValues,
+} from "@/lib/templates";
 import {
   assertDemoDeployRateLimit,
   assertDemoProjectCreateAllowed,
   assertDemoServiceCreateAllowed,
 } from "./demo-guards";
 import { os } from "./orpc";
+
+function buildManagedDatabaseReferenceValues(input: {
+  host: string;
+  port: number;
+  username: string;
+  password: string;
+  database: string;
+}): Record<string, string> {
+  return {
+    HOST: input.host,
+    PORT: String(input.port),
+    USERNAME: input.username,
+    PASSWORD: input.password,
+    DATABASE: input.database,
+    DATABASE_URL: buildPostgresConnectionString({
+      username: input.username,
+      password: input.password,
+      host: input.host,
+      port: input.port,
+      database: input.database,
+      ssl: true,
+    }),
+    POSTGRES_USER: input.username,
+    POSTGRES_PASSWORD: input.password,
+    POSTGRES_DB: input.database,
+  };
+}
 
 export const projects = {
   list: os.projects.list.handler(async () => {
@@ -153,8 +190,9 @@ export const projects = {
     await assertDemoProjectCreateAllowed();
 
     let template: ReturnType<typeof getTemplate> | null = null;
-    let resolvedTemplateServices: ReturnType<typeof resolveTemplateServices> =
-      [];
+    let managedTemplateDatabases: ReturnType<
+      typeof getManagedTemplateDatabases
+    > = [];
 
     if (input.templateId) {
       template = getTemplate(input.templateId);
@@ -169,17 +207,7 @@ export const projects = {
         });
       }
 
-      resolvedTemplateServices = resolveTemplateServices(template);
-      if (
-        resolvedTemplateServices.some(function hasDatabaseService(svc) {
-          return svc.isDatabase;
-        })
-      ) {
-        throw new ORPCError("BAD_REQUEST", {
-          message:
-            "Project templates with database services are not supported in this version",
-        });
-      }
+      managedTemplateDatabases = getManagedTemplateDatabases(template);
     }
 
     const id = newProjectId();
@@ -223,35 +251,74 @@ export const projects = {
     }
 
     if (template) {
-      await assertDemoServiceCreateAllowed(
-        envId,
-        resolvedTemplateServices.length,
-      );
+      try {
+        const excludedServices = managedTemplateDatabases.map(
+          function getName(database) {
+            return database.name;
+          },
+        );
+        const templateReferenceValues: TemplateReferenceValues = {};
 
-      for (const svc of resolvedTemplateServices) {
-        const serviceHostname = slugify(svc.name);
+        for (const databaseTemplate of managedTemplateDatabases) {
+          const createdDatabase = await createDatabase({
+            projectId: id,
+            name: databaseTemplate.name,
+            engine: databaseTemplate.engine,
+            image: databaseTemplate.image,
+          });
+          const connection = await getDatabaseTargetConnectionInfo({
+            databaseId: createdDatabase.database.id,
+            targetId: createdDatabase.target.id,
+          });
 
-        const service = await createService({
-          environmentId: envId,
-          name: svc.name,
-          hostname: serviceHostname,
-          deployType: "image",
-          serviceType: "app",
-          imageUrl: svc.image,
-          envVars: svc.envVars,
-          containerPort: svc.port,
-          healthCheckPath: svc.healthCheckPath,
-          healthCheckTimeout: svc.healthCheckTimeout,
-          volumes: svc.volumes,
-          command: svc.command,
-          icon: svc.icon,
-          ssl: svc.ssl,
-          wildcardDomain: { projectHostname: hostname },
+          templateReferenceValues[databaseTemplate.name] =
+            buildManagedDatabaseReferenceValues({
+              host: connection.internalHost,
+              port: 5432,
+              username: connection.username,
+              password: connection.password,
+              database: connection.database,
+            });
+        }
+
+        const resolvedTemplateServices = resolveTemplateServices(template, {
+          excludeServices: excludedServices,
+          referenceValues: templateReferenceValues,
         });
 
-        deployService(service.id).catch((err) => {
-          console.error(`Auto-deploy failed for service ${service.id}:`, err);
-        });
+        await assertDemoServiceCreateAllowed(
+          envId,
+          resolvedTemplateServices.length,
+        );
+
+        for (const svc of resolvedTemplateServices) {
+          const serviceHostname = slugify(svc.name);
+
+          const service = await createService({
+            environmentId: envId,
+            name: svc.name,
+            hostname: serviceHostname,
+            deployType: "image",
+            serviceType: svc.isDatabase ? "database" : "app",
+            imageUrl: svc.image,
+            envVars: svc.envVars,
+            containerPort: svc.port,
+            healthCheckPath: svc.healthCheckPath,
+            healthCheckTimeout: svc.healthCheckTimeout,
+            volumes: svc.volumes,
+            command: svc.command,
+            icon: svc.icon,
+            ssl: svc.ssl,
+            wildcardDomain: { projectHostname: hostname },
+          });
+
+          deployService(service.id).catch((err) => {
+            console.error(`Auto-deploy failed for service ${service.id}:`, err);
+          });
+        }
+      } catch (error) {
+        await cleanupProject(id);
+        throw error;
       }
     }
 

--- a/apps/app/templates/README.md
+++ b/apps/app/templates/README.md
@@ -60,10 +60,23 @@ Use `generated` to auto-generate credentials:
 In project templates, reference other services' environment variables:
 
 ```yaml
-DATABASE_URL: postgres://user:${postgres.POSTGRES_PASSWORD}@postgres:5432/db
+DATABASE_URL: ${postgres.DATABASE_URL}
+DB_HOST: ${postgres.HOST}
+DB_USER: ${postgres.USERNAME}
 ```
 
 Format: `${service_name.ENV_VAR_NAME}`
+
+Built-in database refs:
+
+- `HOST`
+- `PORT`
+- `USERNAME`
+- `PASSWORD`
+- `DATABASE`
+- `DATABASE_URL`
+
+Project templates can keep services like `clickhouse` and `mysql` as normal services while `postgres` database services are created as Frost databases.
 
 ## Contributing
 

--- a/apps/app/templates/projects/ghost.yaml
+++ b/apps/app/templates/projects/ghost.yaml
@@ -12,10 +12,10 @@ services:
     environment:
       url: http://localhost:2368
       database__client: mysql
-      database__connection__host: mysql
-      database__connection__user: ghost
-      database__connection__password: ${mysql.MYSQL_PASSWORD}
-      database__connection__database: ghost
+      database__connection__host: ${mysql.HOST}
+      database__connection__user: ${mysql.USERNAME}
+      database__connection__password: ${mysql.PASSWORD}
+      database__connection__database: ${mysql.DATABASE}
     volumes:
       - data:/var/lib/ghost/content
     health_check:

--- a/apps/app/templates/projects/hasura.yaml
+++ b/apps/app/templates/projects/hasura.yaml
@@ -10,7 +10,7 @@ services:
     main: true
     icon: hasura
     environment:
-      HASURA_GRAPHQL_DATABASE_URL: postgres://postgres:${postgres.POSTGRES_PASSWORD}@postgres:5432/hasura
+      HASURA_GRAPHQL_DATABASE_URL: ${postgres.DATABASE_URL}
       HASURA_GRAPHQL_ENABLE_CONSOLE: "true"
       HASURA_GRAPHQL_DEV_MODE: "false"
       HASURA_GRAPHQL_ADMIN_SECRET:

--- a/apps/app/templates/projects/n8n.yaml
+++ b/apps/app/templates/projects/n8n.yaml
@@ -11,11 +11,11 @@ services:
     icon: n8n
     environment:
       DB_TYPE: postgresdb
-      DB_POSTGRESDB_HOST: postgres
-      DB_POSTGRESDB_PORT: "5432"
-      DB_POSTGRESDB_DATABASE: n8n
-      DB_POSTGRESDB_USER: n8n
-      DB_POSTGRESDB_PASSWORD: ${postgres.POSTGRES_PASSWORD}
+      DB_POSTGRESDB_HOST: ${postgres.HOST}
+      DB_POSTGRESDB_PORT: ${postgres.PORT}
+      DB_POSTGRESDB_DATABASE: ${postgres.DATABASE}
+      DB_POSTGRESDB_USER: ${postgres.USERNAME}
+      DB_POSTGRESDB_PASSWORD: ${postgres.PASSWORD}
       N8N_ENCRYPTION_KEY:
         generated: base64_32
     volumes:

--- a/apps/app/templates/projects/plausible.yaml
+++ b/apps/app/templates/projects/plausible.yaml
@@ -11,8 +11,8 @@ services:
     command: /entrypoint.sh db createdb && /entrypoint.sh db migrate && /entrypoint.sh run
     environment:
       BASE_URL: http://localhost:8000
-      DATABASE_URL: postgres://postgres:${postgres.POSTGRES_PASSWORD}@postgres:5432/plausible
-      CLICKHOUSE_DATABASE_URL: http://clickhouse:8123/plausible_events_db
+      DATABASE_URL: ${postgres.DATABASE_URL}
+      CLICKHOUSE_DATABASE_URL: http://${clickhouse.HOST}:${clickhouse.PORT}/plausible_events_db
       SECRET_KEY_BASE:
         generated: base64_64
       TOTP_VAULT_KEY:

--- a/apps/app/templates/projects/strapi.yaml
+++ b/apps/app/templates/projects/strapi.yaml
@@ -11,11 +11,11 @@ services:
     icon: strapi
     environment:
       DATABASE_CLIENT: postgres
-      DATABASE_HOST: postgres
-      DATABASE_PORT: "5432"
-      DATABASE_NAME: strapi
-      DATABASE_USERNAME: strapi
-      DATABASE_PASSWORD: ${postgres.POSTGRES_PASSWORD}
+      DATABASE_HOST: ${postgres.HOST}
+      DATABASE_PORT: ${postgres.PORT}
+      DATABASE_NAME: ${postgres.DATABASE}
+      DATABASE_USERNAME: ${postgres.USERNAME}
+      DATABASE_PASSWORD: ${postgres.PASSWORD}
       APP_KEYS:
         generated: base64_32
       API_TOKEN_SALT:

--- a/apps/app/templates/projects/umami.yaml
+++ b/apps/app/templates/projects/umami.yaml
@@ -10,7 +10,7 @@ services:
     main: true
     icon: umami
     environment:
-      DATABASE_URL: postgres://postgres:${postgres.POSTGRES_PASSWORD}@postgres:5432/umami
+      DATABASE_URL: ${postgres.DATABASE_URL}
       APP_SECRET:
         generated: base64_32
     health_check:

--- a/apps/app/templates/projects/wordpress.yaml
+++ b/apps/app/templates/projects/wordpress.yaml
@@ -10,10 +10,10 @@ services:
     main: true
     icon: wordpress
     environment:
-      WORDPRESS_DB_HOST: mysql
-      WORDPRESS_DB_USER: wordpress
-      WORDPRESS_DB_PASSWORD: ${mysql.MYSQL_PASSWORD}
-      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DB_HOST: ${mysql.HOST}
+      WORDPRESS_DB_USER: ${mysql.USERNAME}
+      WORDPRESS_DB_PASSWORD: ${mysql.PASSWORD}
+      WORDPRESS_DB_NAME: ${mysql.DATABASE}
     volumes:
       - data:/var/www/html
     health_check:

--- a/apps/marketing/src/app/docs/guides/templates/page.mdx
+++ b/apps/marketing/src/app/docs/guides/templates/page.mdx
@@ -20,4 +20,11 @@ Templates can auto-generate secure values for passwords and tokens. Fields like 
 
 ## Cross-Service References
 
-In project templates, services can reference each other's environment variables. For example, a web app template might reference the database password from the postgres service, so connection strings are configured automatically.
+In project templates, services can reference each other's environment variables. Database templates also get built-in refs like `HOST`, `PORT`, `USERNAME`, `PASSWORD`, `DATABASE`, and `DATABASE_URL`.
+
+Example:
+
+```yaml
+DATABASE_URL: ${postgres.DATABASE_URL}
+DB_HOST: ${postgres.HOST}
+```


### PR DESCRIPTION
## Summary
- create Frost-managed postgres databases from project templates
- resolve template database refs like `${postgres.DATABASE_URL}` and update postgres-backed templates
- keep mysql and clickhouse as regular services, with tests, docs, and e2e updated

## Testing
- bun test apps/app/src/lib/templates.test.ts
- bun run typecheck
- bun run lint
