### PR TITLE
fix(e2e): retry network curl checks

### DIFF
--- a/apps/app/scripts/e2e-local.sh
+++ b/apps/app/scripts/e2e-local.sh
@@ -96,7 +96,7 @@ if [ "${E2E_SKIP_PREPULL:-0}" != "1" ]; then
   if [ -n "${E2E_PREPULL_IMAGES:-}" ]; then
     read -r -a PREPULL_IMAGES <<< "$E2E_PREPULL_IMAGES"
   else
-    PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11")
+    PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11" "curlimages/curl")
   fi
 
   if [ "${#PREPULL_IMAGES[@]}" -gt 0 ]; then

--- a/apps/app/scripts/e2e-test.sh
+++ b/apps/app/scripts/e2e-test.sh
@@ -33,7 +33,7 @@ PREPULL_BACKOFF_SEC="${E2E_PREPULL_BACKOFF_SEC:-2}"
 if [ -n "${E2E_PREPULL_IMAGES:-}" ]; then
   read -r -a PREPULL_IMAGES <<< "${E2E_PREPULL_IMAGES}"
 else
-  PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11")
+  PREPULL_IMAGES=("nginx:alpine" "httpd:alpine" "postgres:17" "node:20-alpine" "mariadb:11" "curlimages/curl")
 fi
 
 for image in "${PREPULL_IMAGES[@]}"; do

--- a/apps/app/scripts/e2e/common.sh
+++ b/apps/app/scripts/e2e/common.sh
@@ -155,6 +155,27 @@ remote() {
   fi
 }
 
+wait_for_network_http_body() {
+  local NETWORK_NAME=$1
+  local URL=$2
+  local EXPECTED=$3
+  local MAX=${4:-10}
+  local SLEEP_SEC=${5:-1}
+  local RESULT=""
+
+  for _ in $(seq 1 "$MAX"); do
+    RESULT=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf $URL" 2>&1 || true)
+    if echo "$RESULT" | grep -q "$EXPECTED"; then
+      echo "$RESULT"
+      return 0
+    fi
+    sleep "$SLEEP_SEC"
+  done
+
+  echo "$RESULT"
+  return 1
+}
+
 wait_for_postgres_tls_value() {
   local HOST=$1
   local PORT=$2

--- a/apps/app/scripts/e2e/group-02-multiservice.sh
+++ b/apps/app/scripts/e2e/group-02-multiservice.sh
@@ -34,8 +34,7 @@ wait_for_deployment "$DEPLOY_FRONTEND_ID" || fail "Frontend deployment failed"
 
 log "Verifying inter-service communication..."
 NETWORK_NAME=$(sanitize_name "frost-net-$PROJECT_ID-$ENV_ID")
-CURL_RESULT=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://backend:80")
-echo "$CURL_RESULT" | grep -q "nginx" || fail "Inter-service communication failed"
+CURL_RESULT=$(wait_for_network_http_body "$NETWORK_NAME" "http://backend:80" "nginx" 10 1) || fail "Inter-service communication failed: $CURL_RESULT"
 log "Inter-service communication works"
 
 log "Cleanup..."

--- a/apps/app/scripts/e2e/group-21-hostname.sh
+++ b/apps/app/scripts/e2e/group-21-hostname.sh
@@ -60,10 +60,8 @@ wait_for_deployment "$DEPLOY3_ID" || fail "Deployment 3 failed"
 
 log "Verifying inter-service communication with both hostnames..."
 NETWORK_NAME=$(sanitize_name "frost-net-$PROJECT_ID-$ENV_ID")
-CURL1=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://my-app:80")
-echo "$CURL1" | grep -q "nginx" || fail "Cannot reach my-app"
-CURL2=$(remote "docker run --rm --network $NETWORK_NAME curlimages/curl -sf http://my-app-2:80")
-echo "$CURL2" | grep -q "nginx" || fail "Cannot reach my-app-2"
+CURL1=$(wait_for_network_http_body "$NETWORK_NAME" "http://my-app:80" "nginx" 10 1) || fail "Cannot reach my-app: $CURL1"
+CURL2=$(wait_for_network_http_body "$NETWORK_NAME" "http://my-app-2:80" "nginx" 10 1) || fail "Cannot reach my-app-2: $CURL2"
 log "Both hostnames resolve correctly"
 
 log "Cleanup..."


### PR DESCRIPTION
## Summary
- retry network curl checks in shared e2e helpers
- use the retry helper in multiservice and hostname groups
- pre-pull `curlimages/curl` in local and VPS e2e runners

## Testing
- `E2E_GROUPS="21-hostname,22-preview-envs,23-change-password,24-zero-downtime" E2E_START_STAGGER_SEC=0 bun run e2e:local 4`
- `E2E_GROUPS="02-multiservice,21-hostname" E2E_START_STAGGER_SEC=0 bun run e2e:local 2`
- `bun run typecheck`
- `bun run lint`
